### PR TITLE
python-telegram-bot==22.6

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# simple find-and-replace changes for python-telegram-bot v22
+e47e780b63c14a9181a5dc6e3711d027b55b7e84
+65f43ec68e4b56f819b6672c65e0dcc8a8fa184c

--- a/chalice.py
+++ b/chalice.py
@@ -6,7 +6,7 @@ import re
 import random
 import redis_db
 from opinion import ENDINGS_REGEX
-from utils import in_whitelist, parse_userid
+from utils import parse_userid
 from datetime import date, datetime
 from _secrets import lucky_numbers
 
@@ -14,8 +14,6 @@ r = redis_db.connect()
 logger = logging.getLogger(__name__)
 
 async def handle_chalice(update: Update, context: CallbackContext):
-    if (not in_whitelist(update)):
-        return
     logger.info(f"[chalice] {update.message.text}")
     match = re.match(r'/[\S]+\s+(.+)', update.message.text)
     if match is None:

--- a/chalice.py
+++ b/chalice.py
@@ -1,7 +1,7 @@
 import logging
 import logging.handlers
 from telegram import Update
-from telegram.ext import Updater, CommandHandler, CallbackContext
+from telegram.ext import Application, CallbackContext, CommandHandler
 import re
 import random
 import redis_db
@@ -90,5 +90,5 @@ async def chalice(update: Update, context: CallbackContext, user_input):
         await update.message.reply_text(reply, do_quote=False)
 
 
-def subscribe(u: Updater):
-    u.dispatcher.add_handler(CommandHandler(("chalice", "cup", "c"), handle_chalice))
+def subscribe(a: Application):
+    a.add_handler(CommandHandler(("chalice", "cup", "c"), handle_chalice))

--- a/chalice.py
+++ b/chalice.py
@@ -19,7 +19,7 @@ async def handle_chalice(update: Update, context: CallbackContext):
     logger.info(f"[chalice] {update.message.text}")
     match = re.match(r'/[\S]+\s+(.+)', update.message.text)
     if match is None:
-        await update.message.reply_text("Какую чашу будем измерять?", quote=True)
+        await update.message.reply_text("Какую чашу будем измерять?", do_quote=True)
         return
     user_input = match.group(1)
     await chalice(update, context, user_input)
@@ -58,7 +58,7 @@ async def chalice(update: Update, context: CallbackContext, user_input):
     ratio = mention_messages / absolute_max
     if mention_messages == 0:
         reply = random.choice([f"Чаша \"{chalice_title}\"... Абсолютно пуста!", f"В чаше \"{chalice_title}\" нет ни капельки!"])
-        await update.message.reply_text(reply, quote=False)
+        await update.message.reply_text(reply, do_quote=False)
     else:
         formatted_ratio = f"{round(ratio * 100)}%"
         reply = f"Чаша \"{chalice_title}\" заполнена на {formatted_ratio}"
@@ -87,7 +87,7 @@ async def chalice(update: Update, context: CallbackContext, user_input):
                 user_info = user_info.upper()
             reply += user_info
 
-        await update.message.reply_text(reply, quote=False)
+        await update.message.reply_text(reply, do_quote=False)
 
 
 def subscribe(u: Updater):

--- a/chalice.py
+++ b/chalice.py
@@ -13,19 +13,19 @@ from _secrets import lucky_numbers
 r = redis_db.connect()
 logger = logging.getLogger(__name__)
 
-def handle_chalice(update: Update, context: CallbackContext):
+async def handle_chalice(update: Update, context: CallbackContext):
     if (not in_whitelist(update)):
         return
     logger.info(f"[chalice] {update.message.text}")
     match = re.match(r'/[\S]+\s+(.+)', update.message.text)
     if match is None:
-        update.message.reply_text("Какую чашу будем измерять?", quote=True)
+        await update.message.reply_text("Какую чашу будем измерять?", quote=True)
         return
     user_input = match.group(1)
-    chalice(update, context, user_input)
+    await chalice(update, context, user_input)
 
 
-def chalice(update: Update, context, user_input):
+async def chalice(update: Update, context: CallbackContext, user_input):
     days_limit = 14
     absolute_max = 56
 
@@ -58,7 +58,7 @@ def chalice(update: Update, context, user_input):
     ratio = mention_messages / absolute_max
     if mention_messages == 0:
         reply = random.choice([f"Чаша \"{chalice_title}\"... Абсолютно пуста!", f"В чаше \"{chalice_title}\" нет ни капельки!"])
-        update.message.reply_text(reply, quote=False)
+        await update.message.reply_text(reply, quote=False)
     else:
         formatted_ratio = f"{round(ratio * 100)}%"
         reply = f"Чаша \"{chalice_title}\" заполнена на {formatted_ratio}"
@@ -87,7 +87,7 @@ def chalice(update: Update, context, user_input):
                 user_info = user_info.upper()
             reply += user_info
 
-        update.message.reply_text(reply, quote=False)
+        await update.message.reply_text(reply, quote=False)
 
 
 def subscribe(u: Updater):

--- a/connect_four.py
+++ b/connect_four.py
@@ -3,7 +3,7 @@ from telegram.ext import Application, CallbackContext, CommandHandler, CallbackQ
 from telegram.error import RetryAfter
 import redis_db
 import re
-from utils import in_whitelist, parse_userid
+from utils import parse_userid
 import random
 import json
 import logging
@@ -70,8 +70,6 @@ def get_cf_keyboard(pregame: bool = False) -> InlineKeyboardMarkup:
 
 
 async def start_cf(update: Update, context: CallbackContext):
-    if (not in_whitelist(update)):
-        return
     match = re.match(r'/[\S]+\s+(.+)', update.message.text)
     if match is None:
         if update.message.reply_to_message is not None:

--- a/connect_four.py
+++ b/connect_four.py
@@ -79,7 +79,7 @@ async def start_cf(update: Update, context: CallbackContext):
         else:
             username_1 = redis_db.get_username_by_id(update.message.from_user.id)
             new_game_state = {"message_id": "", "player_ids": [update.message.from_user.id, None], "player_usernames": [username_1, ""], "current_turn": random.choice([0, 1]), "board": [[-1 for col in range(0, 7)] for row in range(0, 6)], "winner": None,}
-            message = await update.message.reply_text(f"{format_playing_field(new_game_state)}", reply_markup=get_cf_keyboard(True), quote=False)
+            message = await update.message.reply_text(f"{format_playing_field(new_game_state)}", reply_markup=get_cf_keyboard(True), do_quote=False)
             new_game_state["message_id"] = str(message.chat_id) + "/" + str(message.message_id)
             games_data.append(new_game_state)
             clean_old_games()
@@ -89,10 +89,10 @@ async def start_cf(update: Update, context: CallbackContext):
 
     if user_id is None:
         await update.message.reply_text(
-            f"Кто такой \"{match.group(1)}\"? Что-то я таких не знаю...", quote=False)
+            f"Кто такой \"{match.group(1)}\"? Что-то я таких не знаю...", do_quote=False)
         return
     elif str(user_id) == str(update.message.from_user.id):
-        await update.message.reply_text("Одиноко? Можешь поиграть со мной! Правда я не очень хорошо умею играть в это (⁄ ⁄•⁄ω⁄•⁄ ⁄)", quote=True)
+        await update.message.reply_text("Одиноко? Можешь поиграть со мной! Правда я не очень хорошо умею играть в это (⁄ ⁄•⁄ω⁄•⁄ ⁄)", do_quote=True)
         return
     
     username_1 = redis_db.get_username_by_id(update.message.from_user.id)
@@ -100,7 +100,7 @@ async def start_cf(update: Update, context: CallbackContext):
     username_2 = context.bot.username if int(user_id) == context.bot.id else redis_db.get_username_by_id(user_id)
     first_turn = 0 if int(user_id) == context.bot.id else random.choice([0, 1]) 
     new_game_state = {"message_id": "", "player_ids": [update.message.from_user.id, int(user_id)], "player_usernames": [username_1, username_2], "current_turn": first_turn, "board": [[-1 for col in range(0, 7)] for row in range(0, 6)], "winner": None,}
-    message = await update.message.reply_text(f"{format_playing_field(new_game_state)}", reply_markup=get_cf_keyboard(False), quote=False)
+    message = await update.message.reply_text(f"{format_playing_field(new_game_state)}", reply_markup=get_cf_keyboard(False), do_quote=False)
     new_game_state["message_id"] = str(message.chat_id) + "/" + str(message.message_id)
     games_data.append(new_game_state)
     clean_old_games()

--- a/connect_four.py
+++ b/connect_four.py
@@ -1,5 +1,5 @@
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
-from telegram.ext import Updater, CommandHandler, CallbackQueryHandler, CallbackContext
+from telegram.ext import Application, CallbackContext, CommandHandler, CallbackQueryHandler
 from telegram.error import RetryAfter
 import redis_db
 import re
@@ -262,6 +262,6 @@ async def try_edit(query, game_state, reply_markup = None) -> bool:
         return True
 
 
-def subscribe(u: Updater):
-    u.dispatcher.add_handler(CommandHandler(("connectfour", "cf"), start_cf))
-    u.dispatcher.add_handler(CallbackQueryHandler(on_cf_action, pattern="^cf_"))
+def subscribe(a: Application):
+    a.add_handler(CommandHandler(("connectfour", "cf"), start_cf))
+    a.add_handler(CallbackQueryHandler(on_cf_action, pattern="^cf_"))

--- a/connect_four.py
+++ b/connect_four.py
@@ -69,7 +69,7 @@ def get_cf_keyboard(pregame: bool = False) -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(keyboard)
 
 
-def start_cf(update: Update, context: CallbackContext):
+async def start_cf(update: Update, context: CallbackContext):
     if (not in_whitelist(update)):
         return
     match = re.match(r'/[\S]+\s+(.+)', update.message.text)
@@ -79,7 +79,7 @@ def start_cf(update: Update, context: CallbackContext):
         else:
             username_1 = redis_db.get_username_by_id(update.message.from_user.id)
             new_game_state = {"message_id": "", "player_ids": [update.message.from_user.id, None], "player_usernames": [username_1, ""], "current_turn": random.choice([0, 1]), "board": [[-1 for col in range(0, 7)] for row in range(0, 6)], "winner": None,}
-            message = update.message.reply_text(f"{format_playing_field(new_game_state)}", reply_markup=get_cf_keyboard(True), quote=False)
+            message = await update.message.reply_text(f"{format_playing_field(new_game_state)}", reply_markup=get_cf_keyboard(True), quote=False)
             new_game_state["message_id"] = str(message.chat_id) + "/" + str(message.message_id)
             games_data.append(new_game_state)
             clean_old_games()
@@ -88,11 +88,11 @@ def start_cf(update: Update, context: CallbackContext):
         user_id = parse_userid(match.group(1), context)
 
     if user_id is None:
-        update.message.reply_text(
+        await update.message.reply_text(
             f"Кто такой \"{match.group(1)}\"? Что-то я таких не знаю...", quote=False)
         return
     elif str(user_id) == str(update.message.from_user.id):
-        update.message.reply_text("Одиноко? Можешь поиграть со мной! Правда я не очень хорошо умею играть в это (⁄ ⁄•⁄ω⁄•⁄ ⁄)", quote=True)
+        await update.message.reply_text("Одиноко? Можешь поиграть со мной! Правда я не очень хорошо умею играть в это (⁄ ⁄•⁄ω⁄•⁄ ⁄)", quote=True)
         return
     
     username_1 = redis_db.get_username_by_id(update.message.from_user.id)
@@ -100,7 +100,7 @@ def start_cf(update: Update, context: CallbackContext):
     username_2 = context.bot.username if int(user_id) == context.bot.id else redis_db.get_username_by_id(user_id)
     first_turn = 0 if int(user_id) == context.bot.id else random.choice([0, 1]) 
     new_game_state = {"message_id": "", "player_ids": [update.message.from_user.id, int(user_id)], "player_usernames": [username_1, username_2], "current_turn": first_turn, "board": [[-1 for col in range(0, 7)] for row in range(0, 6)], "winner": None,}
-    message = update.message.reply_text(f"{format_playing_field(new_game_state)}", reply_markup=get_cf_keyboard(False), quote=False)
+    message = await update.message.reply_text(f"{format_playing_field(new_game_state)}", reply_markup=get_cf_keyboard(False), quote=False)
     new_game_state["message_id"] = str(message.chat_id) + "/" + str(message.message_id)
     games_data.append(new_game_state)
     clean_old_games()
@@ -144,7 +144,7 @@ def check_draw(game_state) -> bool:
     return True
 
 
-def on_cf_action(update: Update, context: CallbackContext):
+async def on_cf_action(update: Update, context: CallbackContext):
     query = update.callback_query
     # Not checking for whitelist because its broken with callback query...
     # But we still check if the message from query exists in our database so all is good!
@@ -156,7 +156,7 @@ def on_cf_action(update: Update, context: CallbackContext):
             break
             
     if game_state is None:
-        query.answer("Не могу найти данные этой игры :(")
+        await query.answer("Не могу найти данные этой игры :(")
         return
     
     if query.data == "cf_join":
@@ -164,10 +164,10 @@ def on_cf_action(update: Update, context: CallbackContext):
             game_state['player_ids'][1] = query.from_user.id
             game_state['player_usernames'][1] = redis_db.get_username_by_id(query.from_user.id)
             try:
-                query.edit_message_text(text=format_playing_field(game_state), reply_markup=get_cf_keyboard(False))
+                await query.edit_message_text(text=format_playing_field(game_state), reply_markup=get_cf_keyboard(False))
             except:
                 game_state['player_ids'][1] = None
-        query.answer()
+        await query.answer()
         return
 
     player_index = -1
@@ -177,7 +177,7 @@ def on_cf_action(update: Update, context: CallbackContext):
             break
 
     if player_index != game_state["current_turn"] or game_state["winner"] is not None:
-        query.answer()
+        await query.answer()
         return
     
     prev_game_state = json.loads(json.dumps(game_state))
@@ -190,7 +190,7 @@ def on_cf_action(update: Update, context: CallbackContext):
             game_state['board'][row_i][col_index] = player_index
             break
     if row_index == -1:
-        query.answer(f'Столбец {col_index + 1} уже заполнен!')
+        await query.answer(f'Столбец {col_index + 1} уже заполнен!')
         return
 
     if check_win_condition_on_cell(game_state, row_index, col_index):
@@ -231,7 +231,7 @@ def on_cf_action(update: Update, context: CallbackContext):
             game_state["current_turn"] = (game_state["current_turn"] + 1) % 2
 
     if game_state["winner"] is not None:
-        edit_res = try_edit(query, game_state, None)
+        edit_res = await try_edit(query, game_state, None)
         if edit_res:
             games_data.remove(game_state)
         else:
@@ -239,26 +239,26 @@ def on_cf_action(update: Update, context: CallbackContext):
                 if state == game_state:
                     games_data[index] = prev_game_state
     else:
-        edit_res = try_edit(query, game_state, query.message.reply_markup)
+        edit_res = await try_edit(query, game_state, query.message.reply_markup)
         if not edit_res:
             for index, state in enumerate(games_data):
                 if state == game_state:
                     games_data[index] = prev_game_state
 
 
-def try_edit(query, game_state, reply_markup = None) -> bool:
+async def try_edit(query, game_state, reply_markup = None) -> bool:
     try:
-        query.edit_message_text(text=format_playing_field(game_state), reply_markup=reply_markup)
-        query.answer()
+        await query.edit_message_text(text=format_playing_field(game_state), reply_markup=reply_markup)
+        await query.answer()
         return True
     # On RetryAfter its guaranteed that the message wont be updated. However if we encounter some other weird error then the message is PROBABLY updated so we return true
     except RetryAfter:
-        query.answer("Не получилось обновить игру из-за защиты от спама :(")
+        await query.answer("Не получилось обновить игру из-за защиты от спама :(")
         return False
     except Exception as e:
         #print(traceback.format_exc())
         print(e)
-        query.answer()
+        await query.answer()
         return True
 
 

--- a/hangman.py
+++ b/hangman.py
@@ -142,7 +142,7 @@ async def start_hangman(update: Update, context: CallbackContext, lang: str):
     if (not in_whitelist(update)):
         return
     new_game_state = {"message_id": "", "answer": "", "guesses": [], "incorrect_guesses": 0, "last_action": "Игра началась!\n", "last_user_id": None, "creator_id": update.message.from_user.id, "creation": True, "l": lang}
-    message = await update.message.reply_text(f"{format_playing_field(new_game_state)}", reply_markup=get_hangman_keyboard([], True, lang), quote=False)
+    message = await update.message.reply_text(f"{format_playing_field(new_game_state)}", reply_markup=get_hangman_keyboard([], True, lang), do_quote=False)
     new_game_state["message_id"] = str(message.chat_id) + "/" + str(message.message_id)
     games_data.append(new_game_state)
     clean_old_games()

--- a/hangman.py
+++ b/hangman.py
@@ -138,11 +138,11 @@ def get_hangman_keyboard(guesses, creation_phase: bool, lang: str) -> InlineKeyb
     return InlineKeyboardMarkup(keyboard)
 
 
-def start_hangman(update: Update, context: CallbackContext, lang: str):
+async def start_hangman(update: Update, context: CallbackContext, lang: str):
     if (not in_whitelist(update)):
         return
     new_game_state = {"message_id": "", "answer": "", "guesses": [], "incorrect_guesses": 0, "last_action": "Игра началась!\n", "last_user_id": None, "creator_id": update.message.from_user.id, "creation": True, "l": lang}
-    message = update.message.reply_text(f"{format_playing_field(new_game_state)}", reply_markup=get_hangman_keyboard([], True, lang), quote=False)
+    message = await update.message.reply_text(f"{format_playing_field(new_game_state)}", reply_markup=get_hangman_keyboard([], True, lang), quote=False)
     new_game_state["message_id"] = str(message.chat_id) + "/" + str(message.message_id)
     games_data.append(new_game_state)
     clean_old_games()
@@ -157,13 +157,13 @@ def is_game_won(game_state) -> bool:
     return True
 
 
-def on_hangman_action(update: Update, context: CallbackContext):
+async def on_hangman_action(update: Update, context: CallbackContext):
     query = update.callback_query
     # Not checking for whitelist because its broken with callback query...
     # But we still check if the message from query exists in our database so all is good!
 
     if query.data == 'h_blank':
-        query.answer()
+        await query.answer()
         return
 
     game_state = None
@@ -174,54 +174,54 @@ def on_hangman_action(update: Update, context: CallbackContext):
             break
             
     if game_state is None:
-        query.answer("Не могу найти данные этой игры :(")
+        await query.answer("Не могу найти данные этой игры :(")
         return
     
     if game_state['creation']:
         if query.from_user.id != game_state['creator_id']:
-            query.answer()
+            await query.answer()
             return
 
         if query.data == 'h_ok':
             if len(game_state['answer'].strip()) <= 2:
-                query.answer("Слишком короткое слово!")
+                await query.answer("Слишком короткое слово!")
                 return
             game_state['creation'] = False
-            edit_res = try_edit(query, game_state, get_hangman_keyboard(game_state['guesses'], False, game_state['l']))
+            edit_res = await try_edit(query, game_state, get_hangman_keyboard(game_state['guesses'], False, game_state['l']))
             if not edit_res:
                 game_state['creation'] = True
-            query.answer()
+            await query.answer()
             return
         elif query.data == 'h_del':
             if len(game_state['answer']) > 0:
                 game_state['answer'] = game_state['answer'][:-1]
-            query.answer(f"Ввод: {game_state['answer']}")
+            await query.answer(f"Ввод: {game_state['answer']}")
             return
         else:
             letter = query.data[2:].lower()
             game_state['answer'] += letter
-            query.answer(f"Ввод: {game_state['answer']}")
+            await query.answer(f"Ввод: {game_state['answer']}")
             return
     
     if query.data == 'h_ok' or query.data == 'h_del':
-        query.answer()
+        await query.answer()
         return
 
     if game_state["incorrect_guesses"] >= MAX_INCORRECT_GUESSES or is_game_won(game_state):
-        query.answer()
+        await query.answer()
         return
     
     if query.from_user.id == game_state['creator_id']:
-        query.answer("Ты не можешь угадывать в своей игре!")
+        await query.answer("Ты не можешь угадывать в своей игре!")
         return
     
     if query.from_user.id == game_state['last_user_id']:
-        query.answer("Ты не можешь угадывать сразу после неудачной попытки!")
+        await query.answer("Ты не можешь угадывать сразу после неудачной попытки!")
         return
 
     letter = query.data[2:].lower()
     if letter in game_state['guesses']:
-        query.answer()
+        await query.answer()
         return
 
     prev_game_state = json.loads(json.dumps(game_state))
@@ -237,7 +237,7 @@ def on_hangman_action(update: Update, context: CallbackContext):
         game_state['last_user_id'] = query.from_user.id
     
     if game_state["incorrect_guesses"] >= MAX_INCORRECT_GUESSES or is_game_won(game_state):
-        edit_res = try_edit(query, game_state, None)
+        edit_res = await try_edit(query, game_state, None)
         if edit_res:
             games_data.remove(game_state)
         else:
@@ -245,25 +245,25 @@ def on_hangman_action(update: Update, context: CallbackContext):
                 if state == game_state:
                     games_data[index] = prev_game_state
     else:
-        edit_res = try_edit(query, game_state, get_hangman_keyboard(game_state['guesses'], False, game_state['l']))
+        edit_res = await try_edit(query, game_state, get_hangman_keyboard(game_state['guesses'], False, game_state['l']))
         if not edit_res:
             for index, state in enumerate(games_data):
                 if state == game_state:
                     games_data[index] = prev_game_state
 
 
-def try_edit(query, game_state, reply_markup = None) -> bool:
+async def try_edit(query, game_state, reply_markup = None) -> bool:
     try:
-        query.edit_message_text(text=format_playing_field(game_state), reply_markup=reply_markup)
-        query.answer()
+        await query.edit_message_text(text=format_playing_field(game_state), reply_markup=reply_markup)
+        await query.answer()
         return True
     except RetryAfter:
-        query.answer("Не получилось обновить игру из-за защиты от спама :(")
+        await query.answer("Не получилось обновить игру из-за защиты от спама :(")
         return False
     except Exception as e:
         #print(traceback.format_exc())
         print(e)
-        query.answer()
+        await query.answer()
         return True
 
 

--- a/hangman.py
+++ b/hangman.py
@@ -2,7 +2,6 @@ from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.error import RetryAfter
 from telegram.ext import Application, CallbackContext, CommandHandler, CallbackQueryHandler
 import redis_db
-from utils import in_whitelist
 import json
 
 r = redis_db.connect()
@@ -139,8 +138,6 @@ def get_hangman_keyboard(guesses, creation_phase: bool, lang: str) -> InlineKeyb
 
 
 async def start_hangman(update: Update, context: CallbackContext, lang: str):
-    if (not in_whitelist(update)):
-        return
     new_game_state = {"message_id": "", "answer": "", "guesses": [], "incorrect_guesses": 0, "last_action": "Игра началась!\n", "last_user_id": None, "creator_id": update.message.from_user.id, "creation": True, "l": lang}
     message = await update.message.reply_text(f"{format_playing_field(new_game_state)}", reply_markup=get_hangman_keyboard([], True, lang), do_quote=False)
     new_game_state["message_id"] = str(message.chat_id) + "/" + str(message.message_id)

--- a/hangman.py
+++ b/hangman.py
@@ -1,6 +1,6 @@
-from telegram import ParseMode, Update, InlineKeyboardButton, InlineKeyboardMarkup
+from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.error import RetryAfter
-from telegram.ext import Updater, CommandHandler, CallbackQueryHandler, CallbackContext
+from telegram.ext import Application, CallbackContext, CommandHandler, CallbackQueryHandler
 import redis_db
 from utils import in_whitelist
 import json
@@ -267,7 +267,7 @@ async def try_edit(query, game_state, reply_markup = None) -> bool:
         return True
 
 
-def subscribe(u: Updater):
-    u.dispatcher.add_handler(CommandHandler(("hangman"), lambda update, context: start_hangman(update, context, "ru")))
-    u.dispatcher.add_handler(CommandHandler(("hangman_english"), lambda update, context: start_hangman(update, context, "en")))
-    u.dispatcher.add_handler(CallbackQueryHandler(on_hangman_action, pattern="^h_"))
+def subscribe(a: Application):
+    a.add_handler(CommandHandler(("hangman"), lambda update, context: start_hangman(update, context, "ru")))
+    a.add_handler(CommandHandler(("hangman_english"), lambda update, context: start_hangman(update, context, "en")))
+    a.add_handler(CallbackQueryHandler(on_hangman_action, pattern="^h_"))

--- a/jerk_of_the_day.py
+++ b/jerk_of_the_day.py
@@ -1,12 +1,13 @@
-from telegram import ParseMode, Update
-from telegram.ext import Updater, CommandHandler
+from telegram import Update
+from telegram.ext import Application, CallbackContext, CommandHandler
+from telegram.constants import ParseMode
 from _secrets import jerk_aliases, lucky_numbers
 import random
 import redis_db
 from utils import in_whitelist
 from datetime import datetime, timedelta, time
 import logging
-from time import sleep
+import asyncio
 
 logger = logging.getLogger(__name__)
 r = redis_db.connect()
@@ -93,9 +94,9 @@ async def jerk_roll(update: Update, context: CallbackContext):
     r.hincrby(JERKS, winner_id, 1)
 
     await update.message.reply_text(f"Выбираю {get_daily_jerk_word()[1]} на сегодня", do_quote=False)
-    sleep(1.5)
+    await asyncio.sleep(1.5)
     await update.message.reply_text(random.choice(["Хмм...", "Так-так-так...", "Расшифровываю результаты...", "Спрашиваем мнения экспертов...", "Дайте подумать..."]), do_quote=False)
-    sleep(1.5)
+    await asyncio.sleep(1.5)
     await update.message.reply_text(f"А вот и победитель — @{winner_username}!", do_quote=False)
     logger.info(f'  WINNER for {cur_datetime_str} is {winner_id}: {winner_username}')
     return
@@ -135,10 +136,10 @@ async def get_jerk_regs(update: Update, context: CallbackContext):
     await update.message.reply_text(f"{message}", do_quote=False)
 
 
-def subscribe(u: Updater):
-    u.dispatcher.add_handler(CommandHandler("reg", jerk_reg))
-    u.dispatcher.add_handler(CommandHandler("unreg", jerk_unreg))
-    u.dispatcher.add_handler(CommandHandler("jerk", jerk_roll))
-    u.dispatcher.add_handler(CommandHandler("jerkstats", get_jerk_stats))
-    u.dispatcher.add_handler(CommandHandler("jerkall", get_jerk_regs))
+def subscribe(a: Application):
+    a.add_handler(CommandHandler("reg", jerk_reg))
+    a.add_handler(CommandHandler("unreg", jerk_unreg))
+    a.add_handler(CommandHandler("jerk", jerk_roll))
+    a.add_handler(CommandHandler("jerkstats", get_jerk_stats))
+    a.add_handler(CommandHandler("jerkall", get_jerk_regs))
     pass

--- a/jerk_of_the_day.py
+++ b/jerk_of_the_day.py
@@ -35,11 +35,11 @@ async def jerk_reg(update: Update, context: CallbackContext):
     count = r.scard(JERKS_REG_SET)
     redis_db.update_user_data(update.message.from_user)
     if already_register:
-        await update.message.reply_text(f"@{reg_user_name}, ты уже участник этой клоунады", quote=False)
+        await update.message.reply_text(f"@{reg_user_name}, ты уже участник этой клоунады", do_quote=False)
         return
     # set user id and username
     r.sadd(JERKS_REG_SET, reg_user_id)
-    await update.message.reply_text(f"@{reg_user_name}, теперь ты участвуешь в лотерее вместе с {count} другими {get_daily_jerk_word()[3]}", quote=False)
+    await update.message.reply_text(f"@{reg_user_name}, теперь ты участвуешь в лотерее вместе с {count} другими {get_daily_jerk_word()[3]}", do_quote=False)
 
 
 async def jerk_unreg(update: Update, context: CallbackContext):
@@ -50,10 +50,10 @@ async def jerk_unreg(update: Update, context: CallbackContext):
     reg_user_name = update.message.from_user.username
     already_register = r.sismember(JERKS_REG_SET, reg_user_id)
     if not already_register:
-        await update.message.reply_text(f"@{reg_user_name}, ты и так не регистрировался", quote=False)
+        await update.message.reply_text(f"@{reg_user_name}, ты и так не регистрировался", do_quote=False)
         return
     r.srem(JERKS_REG_SET, reg_user_id)
-    await update.message.reply_text(f"Правильное решение, @{reg_user_name}. Вычеркнул тебя из списка", quote=False)
+    await update.message.reply_text(f"Правильное решение, @{reg_user_name}. Вычеркнул тебя из списка", do_quote=False)
 
 
 async def jerk_roll(update: Update, context: CallbackContext):
@@ -81,22 +81,22 @@ async def jerk_roll(update: Update, context: CallbackContext):
             await update.message.reply_text(f"Сегодняшний {get_daily_jerk_word()[0]} дня: <b>{cur_jerk_username}</b>.\n"
                                       f"Следующий запуск будет доступен через: "
                                       f"{time_to_next_h} ч. и {time_to_next_m} м.",
-                                      quote=False, parse_mode=ParseMode.HTML)
+                                      do_quote=False, parse_mode=ParseMode.HTML)
             return
     players = list(r.smembers(JERKS_REG_SET))
     if (len(players) == 0):
-        await update.message.reply_text("А че вы роллить собрались? Никто не зарегистрировался", quote=True)
+        await update.message.reply_text("А че вы роллить собрались? Никто не зарегистрировался", do_quote=True)
     winner_id = random.choice(players)
     winner_username = redis_db.get_username_by_id(winner_id)
     r.hset(JERKS_META, 'last_jerk', winner_id)
     r.hset(JERKS_META, 'roll_time', cur_datetime_str)
     r.hincrby(JERKS, winner_id, 1)
 
-    await update.message.reply_text(f"Выбираю {get_daily_jerk_word()[1]} на сегодня", quote=False)
+    await update.message.reply_text(f"Выбираю {get_daily_jerk_word()[1]} на сегодня", do_quote=False)
     sleep(1.5)
-    await update.message.reply_text(random.choice(["Хмм...", "Так-так-так...", "Расшифровываю результаты...", "Спрашиваем мнения экспертов...", "Дайте подумать..."]), quote=False)
+    await update.message.reply_text(random.choice(["Хмм...", "Так-так-так...", "Расшифровываю результаты...", "Спрашиваем мнения экспертов...", "Дайте подумать..."]), do_quote=False)
     sleep(1.5)
-    await update.message.reply_text(f"А вот и победитель — @{winner_username}!", quote=False)
+    await update.message.reply_text(f"А вот и победитель — @{winner_username}!", do_quote=False)
     logger.info(f'  WINNER for {cur_datetime_str} is {winner_id}: {winner_username}')
     return
 
@@ -117,7 +117,7 @@ async def get_jerk_stats(update: Update, context: CallbackContext):
     for k, v in dict(sorted(jerks_dict.items(), key=lambda item: item[1], reverse=True)).items():
         message += f"{i}. {k} — {v} {lucky_numbers.get(v, '')}\n"
         i += 1
-    await update.message.reply_text(f"{message}", quote=False)
+    await update.message.reply_text(f"{message}", do_quote=False)
 
 
 async def get_jerk_regs(update: Update, context: CallbackContext):
@@ -125,14 +125,14 @@ async def get_jerk_regs(update: Update, context: CallbackContext):
         return
     players = r.smembers(JERKS_REG_SET)
     if (len(players) == 0):
-        await update.message.reply_text(f"Никто не зарегистрировался на {get_daily_jerk_word()[1]} дня...", quote=False)
+        await update.message.reply_text(f"Никто не зарегистрировался на {get_daily_jerk_word()[1]} дня...", do_quote=False)
         return
     message = "Вот все известные мне персонажи:\n"
     i = 1
     for player in players:
         message += f"{i}. {redis_db.get_username_by_id(player)}\n"
         i += 1
-    await update.message.reply_text(f"{message}", quote=False)
+    await update.message.reply_text(f"{message}", do_quote=False)
 
 
 def subscribe(u: Updater):

--- a/jerk_of_the_day.py
+++ b/jerk_of_the_day.py
@@ -24,7 +24,7 @@ def get_daily_jerk_word() -> list:
     return my_random.choice(jerk_aliases)
 
 
-def jerk_reg(update: Update, context):
+async def jerk_reg(update: Update, context: CallbackContext):
     if not in_whitelist(update):
         return
     # set user id to regs
@@ -35,14 +35,14 @@ def jerk_reg(update: Update, context):
     count = r.scard(JERKS_REG_SET)
     redis_db.update_user_data(update.message.from_user)
     if already_register:
-        update.message.reply_text(f"@{reg_user_name}, ты уже участник этой клоунады", quote=False)
+        await update.message.reply_text(f"@{reg_user_name}, ты уже участник этой клоунады", quote=False)
         return
     # set user id and username
     r.sadd(JERKS_REG_SET, reg_user_id)
-    update.message.reply_text(f"@{reg_user_name}, теперь ты участвуешь в лотерее вместе с {count} другими {get_daily_jerk_word()[3]}", quote=False)
+    await update.message.reply_text(f"@{reg_user_name}, теперь ты участвуешь в лотерее вместе с {count} другими {get_daily_jerk_word()[3]}", quote=False)
 
 
-def jerk_unreg(update: Update, context):
+async def jerk_unreg(update: Update, context: CallbackContext):
     if not in_whitelist(update):
         return
     logger.info('[jerk_unreg]')
@@ -50,13 +50,13 @@ def jerk_unreg(update: Update, context):
     reg_user_name = update.message.from_user.username
     already_register = r.sismember(JERKS_REG_SET, reg_user_id)
     if not already_register:
-        update.message.reply_text(f"@{reg_user_name}, ты и так не регистрировался", quote=False)
+        await update.message.reply_text(f"@{reg_user_name}, ты и так не регистрировался", quote=False)
         return
     r.srem(JERKS_REG_SET, reg_user_id)
-    update.message.reply_text(f"Правильное решение, @{reg_user_name}. Вычеркнул тебя из списка", quote=False)
+    await update.message.reply_text(f"Правильное решение, @{reg_user_name}. Вычеркнул тебя из списка", quote=False)
 
 
-def jerk_roll(update: Update, context):
+async def jerk_roll(update: Update, context: CallbackContext):
     if (not in_whitelist(update)):
         return
     logger.info('[jerk_of_the_day]')
@@ -78,30 +78,30 @@ def jerk_roll(update: Update, context):
             tomorrow = cur_datetime + timedelta(days=1)
             time_to_next = datetime.combine(tomorrow, time.min) - cur_datetime
             time_to_next_h, time_to_next_m = time_to_next.seconds // 3600, (time_to_next.seconds // 60) % 60
-            update.message.reply_text(f"Сегодняшний {get_daily_jerk_word()[0]} дня: <b>{cur_jerk_username}</b>.\n"
+            await update.message.reply_text(f"Сегодняшний {get_daily_jerk_word()[0]} дня: <b>{cur_jerk_username}</b>.\n"
                                       f"Следующий запуск будет доступен через: "
                                       f"{time_to_next_h} ч. и {time_to_next_m} м.",
                                       quote=False, parse_mode=ParseMode.HTML)
             return
     players = list(r.smembers(JERKS_REG_SET))
     if (len(players) == 0):
-        update.message.reply_text("А че вы роллить собрались? Никто не зарегистрировался", quote=True)
+        await update.message.reply_text("А че вы роллить собрались? Никто не зарегистрировался", quote=True)
     winner_id = random.choice(players)
     winner_username = redis_db.get_username_by_id(winner_id)
     r.hset(JERKS_META, 'last_jerk', winner_id)
     r.hset(JERKS_META, 'roll_time', cur_datetime_str)
     r.hincrby(JERKS, winner_id, 1)
 
-    update.message.reply_text(f"Выбираю {get_daily_jerk_word()[1]} на сегодня", quote=False)
+    await update.message.reply_text(f"Выбираю {get_daily_jerk_word()[1]} на сегодня", quote=False)
     sleep(1.5)
-    update.message.reply_text(random.choice(["Хмм...", "Так-так-так...", "Расшифровываю результаты...", "Спрашиваем мнения экспертов...", "Дайте подумать..."]), quote=False)
+    await update.message.reply_text(random.choice(["Хмм...", "Так-так-так...", "Расшифровываю результаты...", "Спрашиваем мнения экспертов...", "Дайте подумать..."]), quote=False)
     sleep(1.5)
-    update.message.reply_text(f"А вот и победитель — @{winner_username}!", quote=False)
+    await update.message.reply_text(f"А вот и победитель — @{winner_username}!", quote=False)
     logger.info(f'  WINNER for {cur_datetime_str} is {winner_id}: {winner_username}')
     return
 
 
-def get_jerk_stats(update: Update, context):
+async def get_jerk_stats(update: Update, context: CallbackContext):
     if (not in_whitelist(update)):
         return
     jerks_dict = {}
@@ -117,22 +117,22 @@ def get_jerk_stats(update: Update, context):
     for k, v in dict(sorted(jerks_dict.items(), key=lambda item: item[1], reverse=True)).items():
         message += f"{i}. {k} — {v} {lucky_numbers.get(v, '')}\n"
         i += 1
-    update.message.reply_text(f"{message}", quote=False)
+    await update.message.reply_text(f"{message}", quote=False)
 
 
-def get_jerk_regs(update: Update, context):
+async def get_jerk_regs(update: Update, context: CallbackContext):
     if (not in_whitelist(update)):
         return
     players = r.smembers(JERKS_REG_SET)
     if (len(players) == 0):
-        update.message.reply_text(f"Никто не зарегистрировался на {get_daily_jerk_word()[1]} дня...", quote=False)    
+        await update.message.reply_text(f"Никто не зарегистрировался на {get_daily_jerk_word()[1]} дня...", quote=False)
         return
     message = "Вот все известные мне персонажи:\n"
     i = 1
     for player in players:
         message += f"{i}. {redis_db.get_username_by_id(player)}\n"
         i += 1
-    update.message.reply_text(f"{message}", quote=False)
+    await update.message.reply_text(f"{message}", quote=False)
 
 
 def subscribe(u: Updater):

--- a/jerk_of_the_day.py
+++ b/jerk_of_the_day.py
@@ -4,7 +4,6 @@ from telegram.constants import ParseMode
 from _secrets import jerk_aliases, lucky_numbers
 import random
 import redis_db
-from utils import in_whitelist
 from datetime import datetime, timedelta, time
 import logging
 import asyncio
@@ -26,8 +25,6 @@ def get_daily_jerk_word() -> list:
 
 
 async def jerk_reg(update: Update, context: CallbackContext):
-    if not in_whitelist(update):
-        return
     # set user id to regs
     logger.info('[jerk_reg]')
     reg_user_id = update.message.from_user.id
@@ -44,8 +41,6 @@ async def jerk_reg(update: Update, context: CallbackContext):
 
 
 async def jerk_unreg(update: Update, context: CallbackContext):
-    if not in_whitelist(update):
-        return
     logger.info('[jerk_unreg]')
     reg_user_id = update.message.from_user.id
     reg_user_name = update.message.from_user.username
@@ -58,8 +53,6 @@ async def jerk_unreg(update: Update, context: CallbackContext):
 
 
 async def jerk_roll(update: Update, context: CallbackContext):
-    if (not in_whitelist(update)):
-        return
     logger.info('[jerk_of_the_day]')
     # r.hdel(JERKS_META, 'roll_time')
 
@@ -103,8 +96,6 @@ async def jerk_roll(update: Update, context: CallbackContext):
 
 
 async def get_jerk_stats(update: Update, context: CallbackContext):
-    if (not in_whitelist(update)):
-        return
     jerks_dict = {}
     for key in r.hgetall(JERKS):
         winner_username = redis_db.get_username_by_id(key)
@@ -122,8 +113,6 @@ async def get_jerk_stats(update: Update, context: CallbackContext):
 
 
 async def get_jerk_regs(update: Update, context: CallbackContext):
-    if (not in_whitelist(update)):
-        return
     players = r.smembers(JERKS_REG_SET)
     if (len(players) == 0):
         await update.message.reply_text(f"Никто не зарегистрировался на {get_daily_jerk_word()[1]} дня...", do_quote=False)

--- a/main.py
+++ b/main.py
@@ -2,8 +2,9 @@ from _secrets import secrets_bot_token, banned_user_ids
 import logging
 import logging.handlers
 import traceback
-from telegram import ParseMode, Update
-from telegram.ext import Updater, CommandHandler, Filters, MessageHandler, CallbackContext
+from telegram import Update
+from telegram.ext import Application, ApplicationBuilder, CallbackContext, CommandHandler, filters, MessageHandler
+from telegram.constants import ParseMode
 import re
 import json
 import random
@@ -487,7 +488,7 @@ async def getAll(update: Update, context: CallbackContext):
     for text in msgs:
         await update.message.reply_text(text, do_quote=False)
 
-async def error(update: Update, context: CallbackContext):
+async def error(update: object, context: CallbackContext):
     tb_list = traceback.format_exception(None, context.error, context.error.__traceback__)
     logger.warning('Exception in update "%s"\n%s\n%s', update, context.error, "".join(tb_list))
 
@@ -542,50 +543,8 @@ def again_setter(func):
     again_function = func
 
 
-if __name__ == '__main__':
-    logger.info("Parsing messages...")
-    redis_db.load_messages()
-
-    logger.info("Setting up telegram bot")
-    u = Updater(secrets_bot_token, use_context=True)
-
-    u.dispatcher.add_handler(CommandHandler("ping", ping))
-    u.dispatcher.add_handler(CommandHandler("get", getDict))
-    u.dispatcher.add_handler(CommandHandler("rawget", rawGetDict))
-    u.dispatcher.add_handler(CommandHandler("set", setDict))
-    u.dispatcher.add_handler(CommandHandler("rndset", rndSetDict))
-    u.dispatcher.add_handler(CommandHandler(("explain", "e"), explain))
-    opinion.subscribe(u, again_setter)
-    u.dispatcher.add_handler(CommandHandler("talk", talk))
-    u.dispatcher.add_handler(CommandHandler("contribute", contribute))
-    u.dispatcher.add_handler(CommandHandler("getall", getAll))
-    u.dispatcher.add_handler(CommandHandler(("randget", "rg"), rand_get))
-    u.dispatcher.add_handler(CommandHandler("del", delDict))
-    u.dispatcher.add_handler(CommandHandler(("again", "a"), again))
-    u.dispatcher.add_handler(CommandHandler("dice", dice))
-    u.dispatcher.add_handler(CommandHandler(("slot", "casino"), casino))
-    markov.subscribe(u, again_setter)
-    jerk_of_the_day.subscribe(u)
-    slap_game.subscribe(u)
-    rps_game.subscribe(u)
-    connect_four.subscribe(u)
-    hangman.subscribe(u)
-    random_cope.subscribe(u)
-    party.subscribe(u)
-    taki.subscribe(u, again_setter)
-    mentions.subscribe(u)
-    chalice.subscribe(u)
-    uptime.subscribe(u)
-
-
-    u.dispatcher.add_handler(CommandHandler("test", lambda update, context: test(update, context)))
-    
-    u.dispatcher.add_handler(MessageHandler(Filters.text & ~Filters.command & ~Filters.forwarded, handle_normal_messages))
-    #u.dispatcher.add_handler(MessageHandler(Filters.sticker | Filters.animation, debug_file_id))
-    u.dispatcher.add_handler(MessageHandler(Filters.command, handle_custom_command))
-    u.dispatcher.add_error_handler(error)
-
-    u.bot.set_my_commands([
+async def post_init(a: Application) -> None:
+    await a.bot.set_my_commands([
         ("ping", "am I alive?"),
         ("get", "<key> get value by key"),
         ("set", "<key> <value> set value by key"),
@@ -634,5 +593,49 @@ if __name__ == '__main__':
         ("uptime", "total time I've been running with no sleep")
     ])
 
+
+if __name__ == '__main__':
+    logger.info("Parsing messages...")
+    redis_db.load_messages()
+
+    logger.info("Setting up telegram bot")
+    a = ApplicationBuilder().token(secrets_bot_token).post_init(post_init).build()
+
+    a.add_handler(CommandHandler("ping", ping))
+    a.add_handler(CommandHandler("get", getDict))
+    a.add_handler(CommandHandler("rawget", rawGetDict))
+    a.add_handler(CommandHandler("set", setDict))
+    a.add_handler(CommandHandler("rndset", rndSetDict))
+    a.add_handler(CommandHandler(("explain", "e"), explain))
+    opinion.subscribe(a, again_setter)
+    a.add_handler(CommandHandler("talk", talk))
+    a.add_handler(CommandHandler("contribute", contribute))
+    a.add_handler(CommandHandler("getall", getAll))
+    a.add_handler(CommandHandler(("randget", "rg"), rand_get))
+    a.add_handler(CommandHandler("del", delDict))
+    a.add_handler(CommandHandler(("again", "a"), again))
+    a.add_handler(CommandHandler("dice", dice))
+    a.add_handler(CommandHandler(("slot", "casino"), casino))
+    markov.subscribe(a, again_setter)
+    jerk_of_the_day.subscribe(a)
+    slap_game.subscribe(a)
+    rps_game.subscribe(a)
+    connect_four.subscribe(a)
+    hangman.subscribe(a)
+    random_cope.subscribe(a)
+    party.subscribe(a)
+    taki.subscribe(a, again_setter)
+    mentions.subscribe(a)
+    chalice.subscribe(a)
+    uptime.subscribe(a)
+
+
+    a.add_handler(CommandHandler("test", lambda update, context: test(update, context)))
+
+    a.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND & ~filters.FORWARDED, handle_normal_messages))
+    #a.add_handler(MessageHandler(filters.Sticker.ALL | filters.ANIMATION, debug_file_id))
+    a.add_handler(MessageHandler(filters.COMMAND, handle_custom_command))
+    a.add_error_handler(error)
+
     logger.info("Started polling for updates")
-    u.start_polling()
+    a.run_polling()

--- a/main.py
+++ b/main.py
@@ -1,9 +1,9 @@
-from _secrets import secrets_bot_token, banned_user_ids
+from _secrets import secrets_bot_token, banned_user_ids, secrets_chat_ids
 import logging
 import logging.handlers
 import traceback
 from telegram import Update
-from telegram.ext import Application, ApplicationBuilder, CallbackContext, CommandHandler, filters, MessageHandler
+from telegram.ext import Application, ApplicationBuilder, ApplicationHandlerStop, CallbackContext, CommandHandler, filters, MessageHandler, TypeHandler
 from telegram.constants import ParseMode
 import re
 import json
@@ -22,7 +22,7 @@ import mentions
 import opinion
 import chalice
 import uptime
-from utils import in_whitelist, PUNCTUATION_REGEX, parse_userid
+from utils import PUNCTUATION_REGEX, parse_userid
 import difflib
 
 rfh = logging.handlers.RotatingFileHandler(filename='debug.log', mode='w', maxBytes=2*1024*1024, backupCount=0,)
@@ -45,13 +45,23 @@ RND_GET_PREFIX =  "#!/RandomizedGet"
 again_function = None
 
 
+async def whitelist_gate(update: Update, context) -> None:
+    # Updates without an effective_chat (like inline queries) pass through ungated
+    if update.effective_chat is not None and update.effective_chat.id not in secrets_chat_ids:
+        logger.warning(f"Chat not whitelisted: {update.effective_chat.id}")
+        # Bots have a global limit of 30 messages per second
+        # https://core.telegram.org/bots/faq#broadcasting-to-users
+        # We don't want to enable ddos attacks for blacklisted chats so we don't message them anything
+        if False:
+            await update.effective_message.reply_text("This chat is not whitelisted")
+        raise ApplicationHandlerStop
+
+
 async def ping(update: Update, context: CallbackContext):
     await update.message.reply_text("Понг!", do_quote=True)
 
 
 async def test(update: Update, context: CallbackContext):
-    if (not in_whitelist(update)):
-        return
     await update.message.reply_text("Looking cool joker!", do_quote=False)
     #print(update.message.link)
     #print(update.message.reply_to_message)
@@ -74,8 +84,6 @@ async def contribute(update: Update, context: CallbackContext):
 
 
 async def getDict(update: Update, context: CallbackContext):
-    if (not in_whitelist(update)):
-        return
     logger.info(f"[getDict] {update.message.text}")
     match = re.match(r'/[\S]+\s+(.+)', update.message.text)
     if (match == None):
@@ -83,15 +91,13 @@ async def getDict(update: Update, context: CallbackContext):
         return
     key = match.group(1).strip()
     key, val = get_close_value_by_key(key)
-        
+
     if val is None:
         await update.message.reply_text("Не помню такого", do_quote=True)
         return
     await send_get_value(update, key, val, show_header=True)
 
 async def rand_get(update: Update, context: CallbackContext, previous_results=[]):
-    if not in_whitelist(update):
-        return
     logger.info(f"[rand_get] {update.message.text}")
     match = re.match(r'/[\S]+\s+([\S]+)', update.message.text)
     if match is None:
@@ -120,8 +126,6 @@ async def rand_get(update: Update, context: CallbackContext, previous_results=[]
 
 
 async def rawGetDict(update: Update, context: CallbackContext):
-    if not in_whitelist(update):
-        return
     logger.info(f"[rawGetDict] {update.message.text}")
     match = re.match(r'/[\S]+\s+(.+)', update.message.text)
     if match is None:
@@ -209,8 +213,6 @@ async def send_get_value(update: Update, key: str, val, show_header, recursion_l
 
 
 async def rndSetDict(update: Update, context: CallbackContext):
-    if not in_whitelist(update):
-        return
     logger.info(f"[rndSetDict] {update.message.text}")
     match = re.match(r'/[\S]+\s+([\S]+)\s+(.+)', update.message.text, re.DOTALL)
     if match is None:
@@ -230,8 +232,6 @@ async def rndSetDict(update: Update, context: CallbackContext):
 
 
 async def setDict(update: Update, context: CallbackContext):
-    if (not in_whitelist(update)):
-        return
     logger.info(f"[setDict] {update.message.text}")
     match = re.match(r'/[\S]+\s+([\S]+)\s+(.+)', update.message.text, re.DOTALL)
     set_as_link = False
@@ -315,8 +315,6 @@ async def send_confirm_set_value(update: Update, key: str, old_value, set_as_lin
 
 
 async def delDict(update: Update, context: CallbackContext):
-    if (not in_whitelist(update)):
-        return
     logger.info(f"[delDict] {update.message.text}")
     match = re.match(r'/[\S]+\s+([\S]+)', update.message.text)
     if (match == None):
@@ -348,8 +346,6 @@ def deep_sentence_matches_definition(definition: str, sentence: list) -> int:
 
 
 async def explain(update: Update, context: CallbackContext, previous_results = []):
-    if (not in_whitelist(update)):
-        return
     logger.info(f"[explain] {update.message.text}")
     match = re.match(r'/[\S]+\s+(.+)', update.message.text)
     if match is None:
@@ -424,8 +420,6 @@ async def explain(update: Update, context: CallbackContext, previous_results = [
 
 
 async def talk(update: Update, context: CallbackContext, previous_results=[]):
-    if (not in_whitelist(update)):
-        return
     match = re.match(r'/[\S]+\s+(.+)', update.message.text)
     user_id = None
     if match == None:
@@ -463,8 +457,6 @@ async def talk(update: Update, context: CallbackContext, previous_results=[]):
 
 
 async def getAll(update: Update, context: CallbackContext):
-    if (not in_whitelist(update)):
-        return
     logger.info("[getAll]")
     match = re.match(r'/[\S]+\s+([^\s]+)', update.message.text)
     search_string = ""
@@ -494,8 +486,6 @@ async def error(update: object, context: CallbackContext):
 
 
 async def again(update: Update, context: CallbackContext):
-    if (not in_whitelist(update)):
-        return
     if again_function:
         try:
             await again_function()
@@ -505,8 +495,6 @@ async def again(update: Update, context: CallbackContext):
         await update.message.reply_text("А что /again? Кажется я все забыл...", do_quote=False)
 
 async def handle_normal_messages(update: Update, context: CallbackContext):
-    if (not in_whitelist(update, send_warning=False)):
-        return
     logger.info(f"[msg] {update.message.text}")
     if (update.message.from_user.id in banned_user_ids):
         logger.info(f"  From banned user {update.message.from_user.id}. Ignored.")
@@ -514,8 +502,6 @@ async def handle_normal_messages(update: Update, context: CallbackContext):
 
 
 async def debug_file_id(update: Update, context: CallbackContext):
-    if (not in_whitelist(update, send_warning=False)):
-        return
     if update.message.sticker is not None:
         logger.info(f"{update.message.sticker.file_id}")
     elif update.message.animation is not None:
@@ -523,8 +509,6 @@ async def debug_file_id(update: Update, context: CallbackContext):
 
 
 async def handle_custom_command(update: Update, context: CallbackContext):
-    if (not in_whitelist(update)):
-        return
     logger.info(f"[custom] {update.message.text}")
     match = re.match(r'(/[^\s@]+)', update.message.text)
     if match is None:
@@ -600,6 +584,8 @@ if __name__ == '__main__':
 
     logger.info("Setting up telegram bot")
     a = ApplicationBuilder().token(secrets_bot_token).post_init(post_init).build()
+
+    a.add_handler(TypeHandler(Update, whitelist_gate), group=-1)
 
     a.add_handler(CommandHandler("ping", ping))
     a.add_handler(CommandHandler("get", getDict))

--- a/main.py
+++ b/main.py
@@ -45,13 +45,13 @@ again_function = None
 
 
 async def ping(update: Update, context: CallbackContext):
-    await update.message.reply_text("Понг!", quote=True)
+    await update.message.reply_text("Понг!", do_quote=True)
 
 
 async def test(update: Update, context: CallbackContext):
     if (not in_whitelist(update)):
         return
-    await update.message.reply_text("Looking cool joker!", quote=False)
+    await update.message.reply_text("Looking cool joker!", do_quote=False)
     #print(update.message.link)
     #print(update.message.reply_to_message)
     #print(update.message.reply_to_message.document)
@@ -61,15 +61,15 @@ async def test(update: Update, context: CallbackContext):
 
 
 async def dice(update: Update, context: CallbackContext):
-    await update.message.reply_dice(quote=False)
+    await update.message.reply_dice(do_quote=False)
 
     
 async def casino(update: Update, context: CallbackContext):
-    await update.message.reply_dice(emoji="🎰", quote=False)
+    await update.message.reply_dice(emoji="🎰", do_quote=False)
 
 
 async def contribute(update: Update, context: CallbackContext):
-    await update.message.reply_text("https://github.com/sunDalik/funny-telegram-bot", quote=False)
+    await update.message.reply_text("https://github.com/sunDalik/funny-telegram-bot", do_quote=False)
 
 
 async def getDict(update: Update, context: CallbackContext):
@@ -78,13 +78,13 @@ async def getDict(update: Update, context: CallbackContext):
     logger.info(f"[getDict] {update.message.text}")
     match = re.match(r'/[\S]+\s+(.+)', update.message.text)
     if (match == None):
-        await update.message.reply_text("Ты чего хочешь-то?", quote=True)
+        await update.message.reply_text("Ты чего хочешь-то?", do_quote=True)
         return
     key = match.group(1).strip()
     key, val = get_close_value_by_key(key)
         
     if val is None:
-        await update.message.reply_text("Не помню такого", quote=True)
+        await update.message.reply_text("Не помню такого", do_quote=True)
         return
     await send_get_value(update, key, val, show_header=True)
 
@@ -102,14 +102,14 @@ async def rand_get(update: Update, context: CallbackContext, previous_results=[]
     if len(keys) == 0:
         if len(previous_results) > 0:
             if search_string == "":
-                await update.message.reply_text("Я уже выдал все, что я знаю T__T", quote=False)
+                await update.message.reply_text("Я уже выдал все, что я знаю T__T", do_quote=False)
             else:
-                await update.message.reply_text(f"Я уже выдал все геты по запросу \"{search_string}\" T__T", quote=False)
+                await update.message.reply_text(f"Я уже выдал все геты по запросу \"{search_string}\" T__T", do_quote=False)
         else:
             if search_string == "":
-                await update.message.reply_text("Не могу найти ни одного гета...", quote=False)
+                await update.message.reply_text("Не могу найти ни одного гета...", do_quote=False)
             else:
-                await update.message.reply_text(f"Не могу найти ни одного гета по запросу \"{search_string}\"...", quote=False)
+                await update.message.reply_text(f"Не могу найти ни одного гета по запросу \"{search_string}\"...", do_quote=False)
         return
     key = random.choice(keys)
     value = r.hget(DICTIONARY_HASH, key)
@@ -124,19 +124,19 @@ async def rawGetDict(update: Update, context: CallbackContext):
     logger.info(f"[rawGetDict] {update.message.text}")
     match = re.match(r'/[\S]+\s+(.+)', update.message.text)
     if match is None:
-        await update.message.reply_text("Ты чего хочешь-то?", quote=True)
+        await update.message.reply_text("Ты чего хочешь-то?", do_quote=True)
         return
     key = match.group(1).strip()
     key, val = get_close_value_by_key(key)
         
     if val is None:
-        await update.message.reply_text("Не помню такого", quote=True)
+        await update.message.reply_text("Не помню такого", do_quote=True)
         return
 
     if val.startswith(RND_GET_PREFIX):
-        await update.message.reply_text(f"/rndset {key} {val[len(RND_GET_PREFIX):]}", quote=False)
+        await update.message.reply_text(f"/rndset {key} {val[len(RND_GET_PREFIX):]}", do_quote=False)
     else:
-        await update.message.reply_text(f"/set {key} {val}", quote=False)
+        await update.message.reply_text(f"/set {key} {val}", do_quote=False)
 
     
 def get_close_value_by_key(key: str):
@@ -158,28 +158,28 @@ async def send_get_value(update: Update, key: str, val, show_header, recursion_l
         await update.message.reply_text(f"Что-то я не помню что такое {key} :<")
     elif val.startswith(POLL_PREFIX + "{"):
         poll_data = json.loads(val[len(POLL_PREFIX):])
-        await update.message.reply_poll(poll_data.get("question", ""), poll_data.get("options", []), is_anonymous=poll_data.get("is_anonymous", False), allows_multiple_answers=poll_data.get("allows_multiple_answers", False), quote=False)
+        await update.message.reply_poll(poll_data.get("question", ""), poll_data.get("options", []), is_anonymous=poll_data.get("is_anonymous", False), allows_multiple_answers=poll_data.get("allows_multiple_answers", False), do_quote=False)
     elif val.startswith(STICKER_PREFIX):
         file_id = val[len(STICKER_PREFIX):]
-        await update.message.reply_sticker(file_id, quote=False)
+        await update.message.reply_sticker(file_id, do_quote=False)
     elif val.startswith(GIF_PREFIX):
         file_id = val[len(GIF_PREFIX):]
         # reply_document should also work
-        await update.message.reply_animation(file_id, quote=False)
+        await update.message.reply_animation(file_id, do_quote=False)
     elif val.startswith(PHOTO_PREFIX):
         values = val[len(PHOTO_PREFIX):].split(CAPTION_DELIMITER, maxsplit=1)
         file_id = values[0]
         caption = values[1] if len(values) > 1 else ""
-        await update.message.reply_photo(file_id, quote=False, caption=caption)
+        await update.message.reply_photo(file_id, do_quote=False, caption=caption)
     elif val.startswith(VIDEO_PREFIX):
         values = val[len(VIDEO_PREFIX):].split(CAPTION_DELIMITER, maxsplit=1)
         file_id = values[0]
         caption = values[1] if len(values) > 1 else ""
-        await update.message.reply_video(file_id, quote=False, caption=caption)
+        await update.message.reply_video(file_id, do_quote=False, caption=caption)
     elif val.startswith(VOICE_PREFIX):
         file_id = val[len(VOICE_PREFIX):]
         # reply_document should also work
-        await update.message.reply_voice(file_id, quote=False)
+        await update.message.reply_voice(file_id, do_quote=False)
     elif val.startswith(RND_GET_PREFIX):
         if recursion_level > 100:
             await update.message.reply_text("Мужик иди в задницу со своей рекурсией")
@@ -199,12 +199,12 @@ async def send_get_value(update: Update, key: str, val, show_header, recursion_l
         if not sent_success and len(values) >= 1:
             await send_get_value(update, values[0], None, show_header=show_header, recursion_level=recursion_level + 1)
     elif val == '🎲' or val == '🎯' or val == '🏀' or val == '⚽️' or val == '🎳' or val == '🎰':
-        await update.message.reply_dice(emoji=val, quote=False)
+        await update.message.reply_dice(emoji=val, do_quote=False)
     else:
         if show_header:
-            await update.message.reply_text(f"{key}\n{val}", quote=False)
+            await update.message.reply_text(f"{key}\n{val}", do_quote=False)
         else:
-            await update.message.reply_text(f"{val}", quote=False)
+            await update.message.reply_text(f"{val}", do_quote=False)
 
 
 async def rndSetDict(update: Update, context: CallbackContext):
@@ -218,7 +218,7 @@ async def rndSetDict(update: Update, context: CallbackContext):
             key = match.group(1)
             values_text = update.message.reply_to_message.text
         else:
-            await update.message.reply_text("Что-то я ничего не понял. Тебе нужно написать в качестве значения разделенный пробелами список ключей, по которым будет делаться /get. Например /rndset key funnyget1 funnyget2 funnyget3", quote=True)
+            await update.message.reply_text("Что-то я ничего не понял. Тебе нужно написать в качестве значения разделенный пробелами список ключей, по которым будет делаться /get. Например /rndset key funnyget1 funnyget2 funnyget3", do_quote=True)
             return
     else:
         key = match.group(1)
@@ -273,10 +273,10 @@ async def setDict(update: Update, context: CallbackContext):
                 set_as_link = True
                 val = update.message.reply_to_message.link
             else:
-                await update.message.reply_text("Что-то я ничего не понял...", quote=True)
+                await update.message.reply_text("Что-то я ничего не понял...", do_quote=True)
                 return
         else:
-            await update.message.reply_text("Что-то я ничего не понял. Удали свой /set и напиши нормально", quote=True)
+            await update.message.reply_text("Что-то я ничего не понял. Удали свой /set и напиши нормально", do_quote=True)
             return
     else:
         key = match.group(1)
@@ -290,27 +290,27 @@ async def send_confirm_set_value(update: Update, key: str, old_value, set_as_lin
     extra_text = " (ссылкой на сообщение)" if set_as_link else ""
     if old_value is not None:
         if old_value.startswith(POLL_PREFIX):
-            await update.message.reply_text(f"Запомнил {key}{extra_text}! Раньше там был какой-то опрос", quote=False)
+            await update.message.reply_text(f"Запомнил {key}{extra_text}! Раньше там был какой-то опрос", do_quote=False)
         elif old_value.startswith(STICKER_PREFIX):
-            await update.message.reply_text(f"Запомнил {key}{extra_text}! Раньше там был какой-то стикер", quote=False)
+            await update.message.reply_text(f"Запомнил {key}{extra_text}! Раньше там был какой-то стикер", do_quote=False)
         elif old_value.startswith(GIF_PREFIX):
-            await update.message.reply_text(f"Запомнил {key}{extra_text}! Раньше там была какая-то гифка", quote=False)
+            await update.message.reply_text(f"Запомнил {key}{extra_text}! Раньше там была какая-то гифка", do_quote=False)
         elif old_value.startswith(PHOTO_PREFIX):
-            await update.message.reply_text(f"Запомнил {key}{extra_text}! Раньше там была какая-то картинка", quote=False)
+            await update.message.reply_text(f"Запомнил {key}{extra_text}! Раньше там была какая-то картинка", do_quote=False)
         elif old_value.startswith(VIDEO_PREFIX):
-            await update.message.reply_text(f"Запомнил {key}{extra_text}! Раньше там было какое-то видео", quote=False)
+            await update.message.reply_text(f"Запомнил {key}{extra_text}! Раньше там было какое-то видео", do_quote=False)
         elif old_value.startswith(VOICE_PREFIX):
-            await update.message.reply_text(f"Запомнил {key}{extra_text}! Раньше там было какое-то голосовое", quote=False)
+            await update.message.reply_text(f"Запомнил {key}{extra_text}! Раньше там было какое-то голосовое", do_quote=False)
         elif old_value.startswith(RND_GET_PREFIX):
-            await update.message.reply_text(f"Запомнил {key}{extra_text}! Раньше там было что-то рандомное", quote=False)
+            await update.message.reply_text(f"Запомнил {key}{extra_text}! Раньше там было что-то рандомное", do_quote=False)
         else:
             output_limit = 100
             if len(old_value) > output_limit:
-                await update.message.reply_text(f"Запомнил {key}{extra_text}! Раньше там было \"{old_value[0:output_limit]}...\" и т.д.", quote=False)
+                await update.message.reply_text(f"Запомнил {key}{extra_text}! Раньше там было \"{old_value[0:output_limit]}...\" и т.д.", do_quote=False)
             else:
-                await update.message.reply_text(f"Запомнил {key}{extra_text}! Раньше там было \"{old_value}\"", quote=False)
+                await update.message.reply_text(f"Запомнил {key}{extra_text}! Раньше там было \"{old_value}\"", do_quote=False)
     else:
-        await update.message.reply_text(f"Запомнил {key}{extra_text}!", quote=False)
+        await update.message.reply_text(f"Запомнил {key}{extra_text}!", do_quote=False)
 
 
 async def delDict(update: Update, context: CallbackContext):
@@ -324,9 +324,9 @@ async def delDict(update: Update, context: CallbackContext):
     key = match.group(1)
     val = r.hdel(DICTIONARY_HASH, key)
     if (val == 0):
-        await update.message.reply_text(f"Чего-чего? \"{key}\"? Я такого не знаю", quote=False)
+        await update.message.reply_text(f"Чего-чего? \"{key}\"? Я такого не знаю", do_quote=False)
     else:
-        await update.message.reply_text(f"Ок, я удалил ключ \"{key}\"", quote=False)
+        await update.message.reply_text(f"Ок, я удалил ключ \"{key}\"", do_quote=False)
 
 
 def sentence_matches_definition(definition: str, sentence: list) -> bool:
@@ -355,7 +355,7 @@ async def explain(update: Update, context: CallbackContext, previous_results = [
         if update.message.reply_to_message is not None and update.message.reply_to_message.text is not None:
             user_input = update.message.reply_to_message.text
         else:
-            await update.message.reply_text("Что тебе объяснить?", quote=True)
+            await update.message.reply_text("Что тебе объяснить?", do_quote=True)
             return
     else:
         user_input = match.group(1)
@@ -411,15 +411,15 @@ async def explain(update: Update, context: CallbackContext, previous_results = [
  
     if not found_explanation:
         if len(previous_results) > 0:
-            await update.message.reply_text(f"Кажется я все уже объяснил про \"{user_input}\"", quote=False)
+            await update.message.reply_text(f"Кажется я все уже объяснил про \"{user_input}\"", do_quote=False)
         else:
-            await update.message.reply_text(f"Я не знаю, что такое \"{user_input}\" ._.", quote=False)
+            await update.message.reply_text(f"Я не знаю, что такое \"{user_input}\" ._.", do_quote=False)
         return
 
     global again_function
     again_function = lambda: explain(update, context, previous_results + [result.lower()])
     logger.info(f"  Result: {result}")
-    await update.message.reply_text(f"<b>{user_input}</b>\n{result}", parse_mode=ParseMode.HTML, quote=False)
+    await update.message.reply_text(f"<b>{user_input}</b>\n{result}", parse_mode=ParseMode.HTML, do_quote=False)
 
 
 async def talk(update: Update, context: CallbackContext, previous_results=[]):
@@ -437,7 +437,7 @@ async def talk(update: Update, context: CallbackContext, previous_results=[]):
     if user_id is None:
         rnd_message = random.choice(redis_db.messages)
         logger.info(f"  Result: {rnd_message}")
-        await update.message.reply_text(rnd_message.text, quote=False)
+        await update.message.reply_text(rnd_message.text, do_quote=False)
     else:
         result = None
         if int(user_id) == context.bot.id:
@@ -452,12 +452,12 @@ async def talk(update: Update, context: CallbackContext, previous_results=[]):
                     result = msg.text
                     break
         if result is None:
-            await update.message.reply_text("...", quote=False)
+            await update.message.reply_text("...", do_quote=False)
         else:
             logger.info(f"  Result: {result}")
             global again_function
             again_function = lambda: talk(update, context, previous_results + [result.lower()])
-            await update.message.reply_text(result, quote=False)
+            await update.message.reply_text(result, do_quote=False)
 
 
 
@@ -475,17 +475,17 @@ async def getAll(update: Update, context: CallbackContext):
     keys.sort()
     if (len(keys) == 0):
         if (search_string != ""):
-            await update.message.reply_text(f"Не нашел никаких гетов по запросу \"{search_string}\" >.>", quote=False)
+            await update.message.reply_text(f"Не нашел никаких гетов по запросу \"{search_string}\" >.>", do_quote=False)
             return
         else:
-            await update.message.reply_text(f"Я пока не знаю никаких гетов... Но ты можешь их добавить командой /set!", quote=False)
+            await update.message.reply_text(f"Я пока не знаю никаких гетов... Но ты можешь их добавить командой /set!", do_quote=False)
             return
     header = 'Так вот же все ГЕТЫ:\n\n' if search_string == "" else f'Вот все ГЕТЫ с \"{search_string}\":\n\n'
     response = header + ", ".join(keys)
     # Telegram has a limit of 4096 characters per message and it doesn't split them automatically
     msgs = [response[i:i + 4096] for i in range(0, len(response), 4096)]
     for text in msgs:
-        await update.message.reply_text(text, quote=False)
+        await update.message.reply_text(text, do_quote=False)
 
 async def error(update: Update, context: CallbackContext):
     tb_list = traceback.format_exception(None, context.error, context.error.__traceback__)
@@ -499,9 +499,9 @@ async def again(update: Update, context: CallbackContext):
         try:
             await again_function()
         except:
-            await update.message.reply_text("А что /again? Кажется я все забыл...", quote=False)
+            await update.message.reply_text("А что /again? Кажется я все забыл...", do_quote=False)
     else:
-        await update.message.reply_text("А что /again? Кажется я все забыл...", quote=False)
+        await update.message.reply_text("А что /again? Кажется я все забыл...", do_quote=False)
 
 async def handle_normal_messages(update: Update, context: CallbackContext):
     if (not in_whitelist(update, send_warning=False)):

--- a/main.py
+++ b/main.py
@@ -44,14 +44,14 @@ RND_GET_PREFIX =  "#!/RandomizedGet"
 again_function = None
 
 
-def ping(update: Update, context):
-    update.message.reply_text("Понг!", quote=True)
+async def ping(update: Update, context: CallbackContext):
+    await update.message.reply_text("Понг!", quote=True)
 
 
-def test(update: Update, context):
+async def test(update: Update, context: CallbackContext):
     if (not in_whitelist(update)):
         return
-    update.message.reply_text("Looking cool joker!", quote=False)
+    await update.message.reply_text("Looking cool joker!", quote=False)
     #print(update.message.link)
     #print(update.message.reply_to_message)
     #print(update.message.reply_to_message.document)
@@ -60,35 +60,35 @@ def test(update: Update, context):
 
 
 
-def dice(update: Update, context):
-    update.message.reply_dice(quote=False)
+async def dice(update: Update, context: CallbackContext):
+    await update.message.reply_dice(quote=False)
 
     
-def casino(update: Update, context):
-    update.message.reply_dice(emoji="🎰", quote=False)
+async def casino(update: Update, context: CallbackContext):
+    await update.message.reply_dice(emoji="🎰", quote=False)
 
 
-def contribute(update: Update, context):
-    update.message.reply_text("https://github.com/sunDalik/funny-telegram-bot", quote=False)
+async def contribute(update: Update, context: CallbackContext):
+    await update.message.reply_text("https://github.com/sunDalik/funny-telegram-bot", quote=False)
 
 
-def getDict(update: Update, context):
+async def getDict(update: Update, context: CallbackContext):
     if (not in_whitelist(update)):
         return
     logger.info(f"[getDict] {update.message.text}")
     match = re.match(r'/[\S]+\s+(.+)', update.message.text)
     if (match == None):
-        update.message.reply_text("Ты чего хочешь-то?", quote=True)
+        await update.message.reply_text("Ты чего хочешь-то?", quote=True)
         return
     key = match.group(1).strip()
     key, val = get_close_value_by_key(key)
         
     if val is None:
-        update.message.reply_text("Не помню такого", quote=True)
+        await update.message.reply_text("Не помню такого", quote=True)
         return
-    send_get_value(update, key, val, show_header=True)
+    await send_get_value(update, key, val, show_header=True)
 
-def rand_get(update: Update, context, previous_results=[]):
+async def rand_get(update: Update, context: CallbackContext, previous_results=[]):
     if not in_whitelist(update):
         return
     logger.info(f"[rand_get] {update.message.text}")
@@ -102,41 +102,41 @@ def rand_get(update: Update, context, previous_results=[]):
     if len(keys) == 0:
         if len(previous_results) > 0:
             if search_string == "":
-                update.message.reply_text("Я уже выдал все, что я знаю T__T", quote=False)
+                await update.message.reply_text("Я уже выдал все, что я знаю T__T", quote=False)
             else:
-                update.message.reply_text(f"Я уже выдал все геты по запросу \"{search_string}\" T__T", quote=False)
+                await update.message.reply_text(f"Я уже выдал все геты по запросу \"{search_string}\" T__T", quote=False)
         else:
             if search_string == "":
-                update.message.reply_text("Не могу найти ни одного гета...", quote=False)
+                await update.message.reply_text("Не могу найти ни одного гета...", quote=False)
             else:
-                update.message.reply_text(f"Не могу найти ни одного гета по запросу \"{search_string}\"...", quote=False)
+                await update.message.reply_text(f"Не могу найти ни одного гета по запросу \"{search_string}\"...", quote=False)
         return
     key = random.choice(keys)
     value = r.hget(DICTIONARY_HASH, key)
     global again_function
     again_function = lambda: rand_get(update, context, previous_results + [key])
-    send_get_value(update, key, value, show_header=True)
+    await send_get_value(update, key, value, show_header=True)
 
 
-def rawGetDict(update: Update, context):
+async def rawGetDict(update: Update, context: CallbackContext):
     if not in_whitelist(update):
         return
     logger.info(f"[rawGetDict] {update.message.text}")
     match = re.match(r'/[\S]+\s+(.+)', update.message.text)
     if match is None:
-        update.message.reply_text("Ты чего хочешь-то?", quote=True)
+        await update.message.reply_text("Ты чего хочешь-то?", quote=True)
         return
     key = match.group(1).strip()
     key, val = get_close_value_by_key(key)
         
     if val is None:
-        update.message.reply_text("Не помню такого", quote=True)
+        await update.message.reply_text("Не помню такого", quote=True)
         return
 
     if val.startswith(RND_GET_PREFIX):
-        update.message.reply_text(f"/rndset {key} {val[len(RND_GET_PREFIX):]}", quote=False)
+        await update.message.reply_text(f"/rndset {key} {val[len(RND_GET_PREFIX):]}", quote=False)
     else:
-        update.message.reply_text(f"/set {key} {val}", quote=False)
+        await update.message.reply_text(f"/set {key} {val}", quote=False)
 
     
 def get_close_value_by_key(key: str):
@@ -149,40 +149,40 @@ def get_close_value_by_key(key: str):
             val = r.hget(DICTIONARY_HASH, key)
     return key, val
 
-def send_get_value(update: Update, key: str, val, show_header, recursion_level = 0):
+async def send_get_value(update: Update, key: str, val, show_header, recursion_level = 0):
     '''
      A very hacky solution that I dont like! I think all dictionary entries should be json values with a type and a value
      So instead of storing plain text we would store {"type": "text", "value": "This is my text"}
     '''
     if val is None:
-        update.message.reply_text(f"Что-то я не помню что такое {key} :<")
+        await update.message.reply_text(f"Что-то я не помню что такое {key} :<")
     elif val.startswith(POLL_PREFIX + "{"):
         poll_data = json.loads(val[len(POLL_PREFIX):])
-        update.message.reply_poll(poll_data.get("question", ""), poll_data.get("options", []), is_anonymous=poll_data.get("is_anonymous", False), allows_multiple_answers=poll_data.get("allows_multiple_answers", False), quote=False)
+        await update.message.reply_poll(poll_data.get("question", ""), poll_data.get("options", []), is_anonymous=poll_data.get("is_anonymous", False), allows_multiple_answers=poll_data.get("allows_multiple_answers", False), quote=False)
     elif val.startswith(STICKER_PREFIX):
         file_id = val[len(STICKER_PREFIX):]
-        update.message.reply_sticker(file_id, quote=False)
+        await update.message.reply_sticker(file_id, quote=False)
     elif val.startswith(GIF_PREFIX):
         file_id = val[len(GIF_PREFIX):]
         # reply_document should also work
-        update.message.reply_animation(file_id, quote=False)
+        await update.message.reply_animation(file_id, quote=False)
     elif val.startswith(PHOTO_PREFIX):
         values = val[len(PHOTO_PREFIX):].split(CAPTION_DELIMITER, maxsplit=1)
         file_id = values[0]
         caption = values[1] if len(values) > 1 else ""
-        update.message.reply_photo(file_id, quote=False, caption=caption)
+        await update.message.reply_photo(file_id, quote=False, caption=caption)
     elif val.startswith(VIDEO_PREFIX):
         values = val[len(VIDEO_PREFIX):].split(CAPTION_DELIMITER, maxsplit=1)
         file_id = values[0]
         caption = values[1] if len(values) > 1 else ""
-        update.message.reply_video(file_id, quote=False, caption=caption)
+        await update.message.reply_video(file_id, quote=False, caption=caption)
     elif val.startswith(VOICE_PREFIX):
         file_id = val[len(VOICE_PREFIX):]
         # reply_document should also work
-        update.message.reply_voice(file_id, quote=False)
+        await update.message.reply_voice(file_id, quote=False)
     elif val.startswith(RND_GET_PREFIX):
         if recursion_level > 100:
-            update.message.reply_text("Мужик иди в задницу со своей рекурсией")
+            await update.message.reply_text("Мужик иди в задницу со своей рекурсией")
             return
         values = [thing for thing in re.split(r'\s+', val[len(RND_GET_PREFIX):]) if thing != ""]
         random.shuffle(values)
@@ -193,21 +193,21 @@ def send_get_value(update: Update, key: str, val, show_header, recursion_level =
             chosen_key, chosen_value = get_close_value_by_key(chosen_key)
             if chosen_value is not None:
                 sent_success = True
-                send_get_value(update, chosen_key, chosen_value, show_header=show_header, recursion_level=recursion_level + 1)
+                await send_get_value(update, chosen_key, chosen_value, show_header=show_header, recursion_level=recursion_level + 1)
                 break
         # If all values are None send the sad notification
         if not sent_success and len(values) >= 1:
-            send_get_value(update, values[0], None, show_header=show_header, recursion_level=recursion_level + 1)
+            await send_get_value(update, values[0], None, show_header=show_header, recursion_level=recursion_level + 1)
     elif val == '🎲' or val == '🎯' or val == '🏀' or val == '⚽️' or val == '🎳' or val == '🎰':
-        update.message.reply_dice(emoji=val, quote=False)
+        await update.message.reply_dice(emoji=val, quote=False)
     else:
         if show_header:
-            update.message.reply_text(f"{key}\n{val}", quote=False)
+            await update.message.reply_text(f"{key}\n{val}", quote=False)
         else:
-            update.message.reply_text(f"{val}", quote=False)
+            await update.message.reply_text(f"{val}", quote=False)
 
 
-def rndSetDict(update: Update, context):
+async def rndSetDict(update: Update, context: CallbackContext):
     if not in_whitelist(update):
         return
     logger.info(f"[rndSetDict] {update.message.text}")
@@ -218,17 +218,17 @@ def rndSetDict(update: Update, context):
             key = match.group(1)
             values_text = update.message.reply_to_message.text
         else:
-            update.message.reply_text("Что-то я ничего не понял. Тебе нужно написать в качестве значения разделенный пробелами список ключей, по которым будет делаться /get. Например /rndset key funnyget1 funnyget2 funnyget3", quote=True)
+            await update.message.reply_text("Что-то я ничего не понял. Тебе нужно написать в качестве значения разделенный пробелами список ключей, по которым будет делаться /get. Например /rndset key funnyget1 funnyget2 funnyget3", quote=True)
             return
     else:
         key = match.group(1)
         values_text = match.group(2)
     old_value = r.hget(DICTIONARY_HASH, key)
     r.hset(DICTIONARY_HASH, key, RND_GET_PREFIX + values_text)
-    send_confirm_set_value(update, key, old_value, False)
+    await send_confirm_set_value(update, key, old_value, False)
 
 
-def setDict(update: Update, context):
+async def setDict(update: Update, context: CallbackContext):
     if (not in_whitelist(update)):
         return
     logger.info(f"[setDict] {update.message.text}")
@@ -273,60 +273,60 @@ def setDict(update: Update, context):
                 set_as_link = True
                 val = update.message.reply_to_message.link
             else:
-                update.message.reply_text("Что-то я ничего не понял...", quote=True)
+                await update.message.reply_text("Что-то я ничего не понял...", quote=True)
                 return
         else:
-            update.message.reply_text("Что-то я ничего не понял. Удали свой /set и напиши нормально", quote=True)
+            await update.message.reply_text("Что-то я ничего не понял. Удали свой /set и напиши нормально", quote=True)
             return
     else:
         key = match.group(1)
         val = match.group(2)
     old_value = r.hget(DICTIONARY_HASH, key)
     r.hset(DICTIONARY_HASH, key, val)
-    send_confirm_set_value(update, key, old_value, set_as_link)
+    await send_confirm_set_value(update, key, old_value, set_as_link)
 
 
-def send_confirm_set_value(update: Update, key: str, old_value, set_as_link: bool):
+async def send_confirm_set_value(update: Update, key: str, old_value, set_as_link: bool):
     extra_text = " (ссылкой на сообщение)" if set_as_link else ""
     if old_value is not None:
         if old_value.startswith(POLL_PREFIX):
-            update.message.reply_text(f"Запомнил {key}{extra_text}! Раньше там был какой-то опрос", quote=False)
+            await update.message.reply_text(f"Запомнил {key}{extra_text}! Раньше там был какой-то опрос", quote=False)
         elif old_value.startswith(STICKER_PREFIX):
-            update.message.reply_text(f"Запомнил {key}{extra_text}! Раньше там был какой-то стикер", quote=False)
+            await update.message.reply_text(f"Запомнил {key}{extra_text}! Раньше там был какой-то стикер", quote=False)
         elif old_value.startswith(GIF_PREFIX):
-            update.message.reply_text(f"Запомнил {key}{extra_text}! Раньше там была какая-то гифка", quote=False)
+            await update.message.reply_text(f"Запомнил {key}{extra_text}! Раньше там была какая-то гифка", quote=False)
         elif old_value.startswith(PHOTO_PREFIX):
-            update.message.reply_text(f"Запомнил {key}{extra_text}! Раньше там была какая-то картинка", quote=False)
+            await update.message.reply_text(f"Запомнил {key}{extra_text}! Раньше там была какая-то картинка", quote=False)
         elif old_value.startswith(VIDEO_PREFIX):
-            update.message.reply_text(f"Запомнил {key}{extra_text}! Раньше там было какое-то видео", quote=False)
+            await update.message.reply_text(f"Запомнил {key}{extra_text}! Раньше там было какое-то видео", quote=False)
         elif old_value.startswith(VOICE_PREFIX):
-            update.message.reply_text(f"Запомнил {key}{extra_text}! Раньше там было какое-то голосовое", quote=False)
+            await update.message.reply_text(f"Запомнил {key}{extra_text}! Раньше там было какое-то голосовое", quote=False)
         elif old_value.startswith(RND_GET_PREFIX):
-            update.message.reply_text(f"Запомнил {key}{extra_text}! Раньше там было что-то рандомное", quote=False)
+            await update.message.reply_text(f"Запомнил {key}{extra_text}! Раньше там было что-то рандомное", quote=False)
         else:
             output_limit = 100
             if len(old_value) > output_limit:
-                update.message.reply_text(f"Запомнил {key}{extra_text}! Раньше там было \"{old_value[0:output_limit]}...\" и т.д.", quote=False)
+                await update.message.reply_text(f"Запомнил {key}{extra_text}! Раньше там было \"{old_value[0:output_limit]}...\" и т.д.", quote=False)
             else:
-                update.message.reply_text(f"Запомнил {key}{extra_text}! Раньше там было \"{old_value}\"", quote=False)
+                await update.message.reply_text(f"Запомнил {key}{extra_text}! Раньше там было \"{old_value}\"", quote=False)
     else:
-        update.message.reply_text(f"Запомнил {key}{extra_text}!", quote=False)
+        await update.message.reply_text(f"Запомнил {key}{extra_text}!", quote=False)
 
 
-def delDict(update: Update, context):
+async def delDict(update: Update, context: CallbackContext):
     if (not in_whitelist(update)):
         return
     logger.info(f"[delDict] {update.message.text}")
     match = re.match(r'/[\S]+\s+([\S]+)', update.message.text)
     if (match == None):
-        update.message.reply_text("Не понял, а что удалить-то хочешь?")
+        await update.message.reply_text("Не понял, а что удалить-то хочешь?")
         return
     key = match.group(1)
     val = r.hdel(DICTIONARY_HASH, key)
     if (val == 0):
-        update.message.reply_text(f"Чего-чего? \"{key}\"? Я такого не знаю", quote=False)
+        await update.message.reply_text(f"Чего-чего? \"{key}\"? Я такого не знаю", quote=False)
     else:
-        update.message.reply_text(f"Ок, я удалил ключ \"{key}\"", quote=False)
+        await update.message.reply_text(f"Ок, я удалил ключ \"{key}\"", quote=False)
 
 
 def sentence_matches_definition(definition: str, sentence: list) -> bool:
@@ -346,7 +346,7 @@ def deep_sentence_matches_definition(definition: str, sentence: list) -> int:
     return -1
 
 
-def explain(update: Update, context, previous_results = []):
+async def explain(update: Update, context: CallbackContext, previous_results = []):
     if (not in_whitelist(update)):
         return
     logger.info(f"[explain] {update.message.text}")
@@ -355,7 +355,7 @@ def explain(update: Update, context, previous_results = []):
         if update.message.reply_to_message is not None and update.message.reply_to_message.text is not None:
             user_input = update.message.reply_to_message.text
         else:
-            update.message.reply_text("Что тебе объяснить?", quote=True)
+            await update.message.reply_text("Что тебе объяснить?", quote=True)
             return
     else:
         user_input = match.group(1)
@@ -411,18 +411,18 @@ def explain(update: Update, context, previous_results = []):
  
     if not found_explanation:
         if len(previous_results) > 0:
-            update.message.reply_text(f"Кажется я все уже объяснил про \"{user_input}\"", quote=False)
+            await update.message.reply_text(f"Кажется я все уже объяснил про \"{user_input}\"", quote=False)
         else:
-            update.message.reply_text(f"Я не знаю, что такое \"{user_input}\" ._.", quote=False)
+            await update.message.reply_text(f"Я не знаю, что такое \"{user_input}\" ._.", quote=False)
         return
 
     global again_function
     again_function = lambda: explain(update, context, previous_results + [result.lower()])
     logger.info(f"  Result: {result}")
-    update.message.reply_text(f"<b>{user_input}</b>\n{result}", parse_mode=ParseMode.HTML, quote=False)
+    await update.message.reply_text(f"<b>{user_input}</b>\n{result}", parse_mode=ParseMode.HTML, quote=False)
 
 
-def talk(update: Update, context: CallbackContext, previous_results=[]):
+async def talk(update: Update, context: CallbackContext, previous_results=[]):
     if (not in_whitelist(update)):
         return
     match = re.match(r'/[\S]+\s+(.+)', update.message.text)
@@ -437,7 +437,7 @@ def talk(update: Update, context: CallbackContext, previous_results=[]):
     if user_id is None:
         rnd_message = random.choice(redis_db.messages)
         logger.info(f"  Result: {rnd_message}")
-        update.message.reply_text(rnd_message.text, quote=False)
+        await update.message.reply_text(rnd_message.text, quote=False)
     else:
         result = None
         if int(user_id) == context.bot.id:
@@ -452,16 +452,16 @@ def talk(update: Update, context: CallbackContext, previous_results=[]):
                     result = msg.text
                     break
         if result is None:
-            update.message.reply_text("...", quote=False)
+            await update.message.reply_text("...", quote=False)
         else:
             logger.info(f"  Result: {result}")
             global again_function
             again_function = lambda: talk(update, context, previous_results + [result.lower()])
-            update.message.reply_text(result, quote=False)
+            await update.message.reply_text(result, quote=False)
 
 
 
-def getAll(update: Update, context):
+async def getAll(update: Update, context: CallbackContext):
     if (not in_whitelist(update)):
         return
     logger.info("[getAll]")
@@ -475,35 +475,35 @@ def getAll(update: Update, context):
     keys.sort()
     if (len(keys) == 0):
         if (search_string != ""):
-            update.message.reply_text(f"Не нашел никаких гетов по запросу \"{search_string}\" >.>", quote=False)
+            await update.message.reply_text(f"Не нашел никаких гетов по запросу \"{search_string}\" >.>", quote=False)
             return
         else:
-            update.message.reply_text(f"Я пока не знаю никаких гетов... Но ты можешь их добавить командой /set!", quote=False)
+            await update.message.reply_text(f"Я пока не знаю никаких гетов... Но ты можешь их добавить командой /set!", quote=False)
             return
     header = 'Так вот же все ГЕТЫ:\n\n' if search_string == "" else f'Вот все ГЕТЫ с \"{search_string}\":\n\n'
     response = header + ", ".join(keys)
     # Telegram has a limit of 4096 characters per message and it doesn't split them automatically
     msgs = [response[i:i + 4096] for i in range(0, len(response), 4096)]
     for text in msgs:
-        update.message.reply_text(text, quote=False)
+        await update.message.reply_text(text, quote=False)
 
-def error(update: Update, context):
+async def error(update: Update, context: CallbackContext):
     tb_list = traceback.format_exception(None, context.error, context.error.__traceback__)
     logger.warning('Exception in update "%s"\n%s\n%s', update, context.error, "".join(tb_list))
 
 
-def again(update: Update, context):
+async def again(update: Update, context: CallbackContext):
     if (not in_whitelist(update)):
         return
     if again_function:
         try:
-            again_function()
+            await again_function()
         except:
-            update.message.reply_text("А что /again? Кажется я все забыл...", quote=False)
+            await update.message.reply_text("А что /again? Кажется я все забыл...", quote=False)
     else:
-        update.message.reply_text("А что /again? Кажется я все забыл...", quote=False)
+        await update.message.reply_text("А что /again? Кажется я все забыл...", quote=False)
 
-def handle_normal_messages(update: Update, context):
+async def handle_normal_messages(update: Update, context: CallbackContext):
     if (not in_whitelist(update, send_warning=False)):
         return
     logger.info(f"[msg] {update.message.text}")
@@ -512,7 +512,7 @@ def handle_normal_messages(update: Update, context):
     redis_db.record_message(update.message)
 
 
-def debug_file_id(update: Update, context):
+async def debug_file_id(update: Update, context: CallbackContext):
     if (not in_whitelist(update, send_warning=False)):
         return
     if update.message.sticker is not None:
@@ -521,7 +521,7 @@ def debug_file_id(update: Update, context):
         logger.info(f"{update.message.animation.file_id}")
 
 
-def handle_custom_command(update: Update, context):
+async def handle_custom_command(update: Update, context: CallbackContext):
     if (not in_whitelist(update)):
         return
     logger.info(f"[custom] {update.message.text}")
@@ -534,7 +534,7 @@ def handle_custom_command(update: Update, context):
     if val is None:
         return
     
-    send_get_value(update, key, val, show_header=False)
+    await send_get_value(update, key, val, show_header=False)
 
 
 def again_setter(func):

--- a/markov.py
+++ b/markov.py
@@ -7,7 +7,7 @@ from typing import Dict, List
 from _secrets import lucky_numbers
 import markovify
 from telegram import Update
-from telegram.ext import Updater, CommandHandler
+from telegram.ext import Application, CallbackContext, CommandHandler
 import re
 import redis_db
 from utils import in_whitelist
@@ -147,7 +147,7 @@ async def markovpost(update: Update, context: CallbackContext, biased_chain=None
             await update.message.reply_text(f'Что-то я ничего смешного про "{query}" не придумал...', do_quote=False)
 
 
-def subscribe(u: Updater, _again_setter):
-    u.dispatcher.add_handler(CommandHandler(("shitpost", "s"), markovpost))
+def subscribe(a: Application, _again_setter):
+    a.add_handler(CommandHandler(("shitpost", "s"), markovpost))
     global again_setter
     again_setter = _again_setter

--- a/markov.py
+++ b/markov.py
@@ -97,7 +97,7 @@ def _score_generated_text(t: str, prev_result_tokens: List[List[str]]) -> float:
     return prev_sim_score + len_score
 
 
-def markovpost(update: Update, context, biased_chain=None, previous_results=[]):
+async def markovpost(update: Update, context: CallbackContext, biased_chain=None, previous_results=[]):
     if not in_whitelist(update):
         return
     logger.info(f"[markov] {update.message.text}")
@@ -108,7 +108,7 @@ def markovpost(update: Update, context, biased_chain=None, previous_results=[]):
         logger.info(f"[markov] Refreshing the model created on {markov_chain_timestamp}")
         markov_chain, markov_chain_timestamp = None, None
     if markov_chain is None:
-        update.message.reply_text("Сначала я должен вспомнить всё... Подожди минутку", quote=True)
+        await update.message.reply_text("Сначала я должен вспомнить всё... Подожди минутку", quote=True)
         markov_chain = _create_chain_from_messages()
         markov_chain_timestamp = datetime.now()
         logger.info(f"[markov] Initialized model with {len(markov_chain.chain.model)} states")
@@ -116,15 +116,15 @@ def markovpost(update: Update, context, biased_chain=None, previous_results=[]):
     match = re.match(r'/[\S]+\s+(.+)', update.message.text)
     if match is None:
         text = markov_chain.make_sentence(max_words=MAX_WORDS_PER_TEXT, tries=MAX_TEXT_GEN_TRIES)
-        update.message.reply_text(text, quote=False)
+        await update.message.reply_text(text, quote=False)
     else:
         query = match.group(1).lower()
         if re.search(r'\s', query):
-            update.message.reply_text(f"Я не умею шутить больше чем про одну вещь за раз >.< Выбери какое-нибудь одно слово", quote=True)
+            await update.message.reply_text(f"Я не умею шутить больше чем про одну вещь за раз >.< Выбери какое-нибудь одно слово", quote=True)
             return
         if biased_chain is None:
             if (biased_chain := _create_biased_chain(markov_chain, query)) is None:
-                update.message.reply_text(f'Дружище, я рад, что тебя так забавляет "{query}", но я ничего смешного в этом не увидел...', quote=False)
+                await update.message.reply_text(f'Дружище, я рад, что тебя так забавляет "{query}", но я ничего смешного в этом не увидел...', quote=False)
                 return
 
         texts = []
@@ -142,9 +142,9 @@ def markovpost(update: Update, context, biased_chain=None, previous_results=[]):
             text, text_try = texts[0]
             if again_setter:
                 again_setter(lambda: markovpost(update, context, biased_chain, previous_results + [text]))
-            update.message.reply_text(f"Прикол #{text_try}{lucky_numbers.get(text_try, '')}. {text.capitalize()}", quote=False)
+            await update.message.reply_text(f"Прикол #{text_try}{lucky_numbers.get(text_try, '')}. {text.capitalize()}", quote=False)
         else:
-            update.message.reply_text(f'Что-то я ничего смешного про "{query}" не придумал...', quote=False)
+            await update.message.reply_text(f'Что-то я ничего смешного про "{query}" не придумал...', quote=False)
 
 
 def subscribe(u: Updater, _again_setter):

--- a/markov.py
+++ b/markov.py
@@ -108,7 +108,7 @@ async def markovpost(update: Update, context: CallbackContext, biased_chain=None
         logger.info(f"[markov] Refreshing the model created on {markov_chain_timestamp}")
         markov_chain, markov_chain_timestamp = None, None
     if markov_chain is None:
-        await update.message.reply_text("Сначала я должен вспомнить всё... Подожди минутку", quote=True)
+        await update.message.reply_text("Сначала я должен вспомнить всё... Подожди минутку", do_quote=True)
         markov_chain = _create_chain_from_messages()
         markov_chain_timestamp = datetime.now()
         logger.info(f"[markov] Initialized model with {len(markov_chain.chain.model)} states")
@@ -116,15 +116,15 @@ async def markovpost(update: Update, context: CallbackContext, biased_chain=None
     match = re.match(r'/[\S]+\s+(.+)', update.message.text)
     if match is None:
         text = markov_chain.make_sentence(max_words=MAX_WORDS_PER_TEXT, tries=MAX_TEXT_GEN_TRIES)
-        await update.message.reply_text(text, quote=False)
+        await update.message.reply_text(text, do_quote=False)
     else:
         query = match.group(1).lower()
         if re.search(r'\s', query):
-            await update.message.reply_text(f"Я не умею шутить больше чем про одну вещь за раз >.< Выбери какое-нибудь одно слово", quote=True)
+            await update.message.reply_text(f"Я не умею шутить больше чем про одну вещь за раз >.< Выбери какое-нибудь одно слово", do_quote=True)
             return
         if biased_chain is None:
             if (biased_chain := _create_biased_chain(markov_chain, query)) is None:
-                await update.message.reply_text(f'Дружище, я рад, что тебя так забавляет "{query}", но я ничего смешного в этом не увидел...', quote=False)
+                await update.message.reply_text(f'Дружище, я рад, что тебя так забавляет "{query}", но я ничего смешного в этом не увидел...', do_quote=False)
                 return
 
         texts = []
@@ -142,9 +142,9 @@ async def markovpost(update: Update, context: CallbackContext, biased_chain=None
             text, text_try = texts[0]
             if again_setter:
                 again_setter(lambda: markovpost(update, context, biased_chain, previous_results + [text]))
-            await update.message.reply_text(f"Прикол #{text_try}{lucky_numbers.get(text_try, '')}. {text.capitalize()}", quote=False)
+            await update.message.reply_text(f"Прикол #{text_try}{lucky_numbers.get(text_try, '')}. {text.capitalize()}", do_quote=False)
         else:
-            await update.message.reply_text(f'Что-то я ничего смешного про "{query}" не придумал...', quote=False)
+            await update.message.reply_text(f'Что-то я ничего смешного про "{query}" не придумал...', do_quote=False)
 
 
 def subscribe(u: Updater, _again_setter):

--- a/markov.py
+++ b/markov.py
@@ -10,7 +10,6 @@ from telegram import Update
 from telegram.ext import Application, CallbackContext, CommandHandler
 import re
 import redis_db
-from utils import in_whitelist
 from difflib import SequenceMatcher
 
 r = redis_db.connect()
@@ -98,8 +97,6 @@ def _score_generated_text(t: str, prev_result_tokens: List[List[str]]) -> float:
 
 
 async def markovpost(update: Update, context: CallbackContext, biased_chain=None, previous_results=[]):
-    if not in_whitelist(update):
-        return
     logger.info(f"[markov] {update.message.text}")
 
     global markov_chain

--- a/mentions.py
+++ b/mentions.py
@@ -15,7 +15,7 @@ async def mentions(update: Update, context: CallbackContext):
     logger.info(f"[mentions] {update.message.text}")
     match = re.match(r'/[\S]+\s+(.+)', update.message.text)
     if match == None:
-        await update.message.reply_text("Упоминания чего будем считать?", quote=True)
+        await update.message.reply_text("Упоминания чего будем считать?", do_quote=True)
         return
     user_input = match.group(1).strip()
     all_messages = [m for m in redis_db.messages]
@@ -33,7 +33,7 @@ async def mentions(update: Update, context: CallbackContext):
                 result[msg.uid] += count
     
     if len(result) == 0:
-        await update.message.reply_text(f"Кажется никто никогда не говорил \"{user_input}\"...\nСтань первым!", quote=False)
+        await update.message.reply_text(f"Кажется никто никогда не говорил \"{user_input}\"...\nСтань первым!", do_quote=False)
         return
 
     message = f"Собрал статистику упоминаний {'фразы' if ' ' in user_input else 'слова'} \"{user_input}\":\n"
@@ -42,7 +42,7 @@ async def mentions(update: Update, context: CallbackContext):
         message += f"{i}. {redis_db.get_username_by_id(k)} — {v}  {lucky_numbers.get(v, '')}\n"
         i += 1
 
-    await update.message.reply_text(message, quote=False)
+    await update.message.reply_text(message, do_quote=False)
 
 
 def subscribe(u: Updater):

--- a/mentions.py
+++ b/mentions.py
@@ -1,7 +1,6 @@
 from telegram import Update
 from telegram.ext import Application, CallbackContext, CommandHandler
 import redis_db
-from utils import in_whitelist
 import logging
 from _secrets import lucky_numbers
 import re
@@ -10,8 +9,6 @@ logger = logging.getLogger(__name__)
 r = redis_db.connect()
 
 async def mentions(update: Update, context: CallbackContext):
-    if (not in_whitelist(update)):
-        return
     logger.info(f"[mentions] {update.message.text}")
     match = re.match(r'/[\S]+\s+(.+)', update.message.text)
     if match == None:

--- a/mentions.py
+++ b/mentions.py
@@ -1,5 +1,5 @@
 from telegram import Update
-from telegram.ext import Updater, CommandHandler
+from telegram.ext import Application, CallbackContext, CommandHandler
 import redis_db
 from utils import in_whitelist
 import logging
@@ -45,5 +45,5 @@ async def mentions(update: Update, context: CallbackContext):
     await update.message.reply_text(message, do_quote=False)
 
 
-def subscribe(u: Updater):
-    u.dispatcher.add_handler(CommandHandler(("mentions", "m", "opinionstats", "os"), mentions))
+def subscribe(a: Application):
+    a.add_handler(CommandHandler(("mentions", "m", "opinionstats", "os"), mentions))

--- a/mentions.py
+++ b/mentions.py
@@ -9,13 +9,13 @@ import re
 logger = logging.getLogger(__name__)
 r = redis_db.connect()
 
-def mentions(update: Update, context):
+async def mentions(update: Update, context: CallbackContext):
     if (not in_whitelist(update)):
         return
     logger.info(f"[mentions] {update.message.text}")
     match = re.match(r'/[\S]+\s+(.+)', update.message.text)
     if match == None:
-        update.message.reply_text("Упоминания чего будем считать?", quote=True)
+        await update.message.reply_text("Упоминания чего будем считать?", quote=True)
         return
     user_input = match.group(1).strip()
     all_messages = [m for m in redis_db.messages]
@@ -33,7 +33,7 @@ def mentions(update: Update, context):
                 result[msg.uid] += count
     
     if len(result) == 0:
-        update.message.reply_text(f"Кажется никто никогда не говорил \"{user_input}\"...\nСтань первым!", quote=False)
+        await update.message.reply_text(f"Кажется никто никогда не говорил \"{user_input}\"...\nСтань первым!", quote=False)
         return
 
     message = f"Собрал статистику упоминаний {'фразы' if ' ' in user_input else 'слова'} \"{user_input}\":\n"
@@ -42,7 +42,7 @@ def mentions(update: Update, context):
         message += f"{i}. {redis_db.get_username_by_id(k)} — {v}  {lucky_numbers.get(v, '')}\n"
         i += 1
 
-    update.message.reply_text(message, quote=False)
+    await update.message.reply_text(message, quote=False)
 
 
 def subscribe(u: Updater):

--- a/opinion.py
+++ b/opinion.py
@@ -13,19 +13,19 @@ again_setter = None
 ENDINGS_REGEX = re.compile(r"(?:ах|а|ев|ей|е|ов|о|иях|ия|ие|ий|й|ь|ы|ии|и|ях|я|у|ых|их|s)$", re.IGNORECASE)
 
 
-def handle_opinion(update: Update, context: CallbackContext):
+async def handle_opinion(update: Update, context: CallbackContext):
     if (not in_whitelist(update)):
         return
     logger.info(f"[opinion] {update.message.text}")
     match = re.match(r'/[\S]+\s+(.+)', update.message.text)
     if match is None:
-        update.message.reply_text("О чем ты хотел узнать мое мнение?", quote=True)
+        await update.message.reply_text("О чем ты хотел узнать мое мнение?", quote=True)
         return
     user_input = match.group(1)
-    opinion(update, context, user_input, [], None)
+    await opinion(update, context, user_input, [], None)
 
 
-def handle_opinion_of(update: Update, context):
+async def handle_opinion_of(update: Update, context: CallbackContext):
     if (not in_whitelist(update)):
         return
     logger.info(f"[opinionof] {update.message.text}")
@@ -36,7 +36,7 @@ def handle_opinion_of(update: Update, context):
             user_id = update.message.reply_to_message.from_user.id
             user_input = match.group(1)
         else:
-            update.message.reply_text("Первым параметром идет имя человека, а потом топик, про который хочешь узнать мнение. Ничему тебя в школе не учили?", quote=True)
+            await update.message.reply_text("Первым параметром идет имя человека, а потом топик, про который хочешь узнать мнение. Ничему тебя в школе не учили?", quote=True)
             return
     else:
         user_name = match.group(1)
@@ -52,13 +52,13 @@ def handle_opinion_of(update: Update, context):
         kansou = random.choice(["Хмм...", "Нуу...", "", "Эээ...", "🤔"])
         results = [("Да ничего я не думаю об этом ._.", 25), ("Да мне как-то все равно...", 25), ("Думаю это супер! ❤️", 80), ("It's ok I guess...", 60), ("Мне нравится!", 100), ("Крутая вещь! 🔥", 30), ("Мне не очень нравится...", 80), ("Такое себе...", 30), ("Это моя самая любимая вещь! 🔥", 10), ("Я ненавижу это! 😡", 10), ("Это худшее, что когда либо было изобретено человечеством", 1),  ("Эта самая лучшая вещь во вселенной!", 1),]
         res = my_random.choices([x for x, w in results], weights=[w for x, w in results])[0]
-        update.message.reply_text(f"{intro} {kansou}\n{res}", quote=False)
+        await update.message.reply_text(f"{intro} {kansou}\n{res}", quote=False)
         return
 
     if user_id is None:
-        update.message.reply_text(f"\"{user_name}\"? Не припоминаю таких", quote=True)
+        await update.message.reply_text(f"\"{user_name}\"? Не припоминаю таких", quote=True)
         return
-    opinion(update, context, user_input, [], user_id)
+    await opinion(update, context, user_input, [], user_id)
 
 
 def try_find_opinion(messages, things, from_user_id, previous_results, user_input):
@@ -88,7 +88,7 @@ def try_find_opinion(messages, things, from_user_id, previous_results, user_inpu
     return None
 
 
-def opinion(update: Update, context, user_input, previous_results=[], from_user_id=None):
+async def opinion(update: Update, context: CallbackContext, user_input, previous_results=[], from_user_id=None):
     things = [thing for thing in re.split(r'\s+', user_input) if thing != ""]
     logger.info(f"  Parse result: {things}")
     shuffled_messages = [m for m in redis_db.messages]
@@ -103,18 +103,18 @@ def opinion(update: Update, context, user_input, previous_results=[], from_user_
 
     if result is None:
         if len(previous_results) > 0 and from_user_id is None:
-            update.message.reply_text(f"Я уже все высказал, что я думаю о \"{user_input}\"", quote=False)
+            await update.message.reply_text(f"Я уже все высказал, что я думаю о \"{user_input}\"", quote=False)
         elif len(previous_results) > 0 and from_user_id is not None:
-            update.message.reply_text(f"Я уже все передал, что {redis_db.get_username_by_id(from_user_id)} думает о \"{user_input}\"", quote=False)
+            await update.message.reply_text(f"Я уже все передал, что {redis_db.get_username_by_id(from_user_id)} думает о \"{user_input}\"", quote=False)
         elif from_user_id is not None:
-            update.message.reply_text(f"Кажется {redis_db.get_username_by_id(from_user_id)} ничего не думает о \"{user_input}\" x_x", quote=False)
+            await update.message.reply_text(f"Кажется {redis_db.get_username_by_id(from_user_id)} ничего не думает о \"{user_input}\" x_x", quote=False)
         else:
-            update.message.reply_text(f"Я ничего не знаю о \"{user_input}\" >_<", quote=False)
+            await update.message.reply_text(f"Я ничего не знаю о \"{user_input}\" >_<", quote=False)
         return
     
     if again_setter:
         again_setter(lambda: opinion(update, context, user_input, previous_results + [result.lower()], from_user_id))
-    update.message.reply_text(result, quote=False)
+    await update.message.reply_text(result, quote=False)
 
 
 def subscribe(u: Updater, _again_setter):

--- a/opinion.py
+++ b/opinion.py
@@ -1,7 +1,7 @@
 import logging
 import logging.handlers
 from telegram import Update
-from telegram.ext import Updater, CommandHandler, CallbackContext
+from telegram.ext import Application, CallbackContext, CommandHandler
 import re
 import random
 import redis_db
@@ -111,14 +111,14 @@ async def opinion(update: Update, context: CallbackContext, user_input, previous
         else:
             await update.message.reply_text(f"Я ничего не знаю о \"{user_input}\" >_<", do_quote=False)
         return
-    
+
     if again_setter:
         again_setter(lambda: opinion(update, context, user_input, previous_results + [result.lower()], from_user_id))
     await update.message.reply_text(result, do_quote=False)
 
 
-def subscribe(u: Updater, _again_setter):
-    u.dispatcher.add_handler(CommandHandler(("opinion", "o"), handle_opinion))
-    u.dispatcher.add_handler(CommandHandler(("opinionof", "oo", "oof"), handle_opinion_of))
+def subscribe(a: Application, _again_setter):
+    a.add_handler(CommandHandler(("opinion", "o"), handle_opinion))
+    a.add_handler(CommandHandler(("opinionof", "oo", "oof"), handle_opinion_of))
     global again_setter
     again_setter = _again_setter

--- a/opinion.py
+++ b/opinion.py
@@ -19,7 +19,7 @@ async def handle_opinion(update: Update, context: CallbackContext):
     logger.info(f"[opinion] {update.message.text}")
     match = re.match(r'/[\S]+\s+(.+)', update.message.text)
     if match is None:
-        await update.message.reply_text("О чем ты хотел узнать мое мнение?", quote=True)
+        await update.message.reply_text("О чем ты хотел узнать мое мнение?", do_quote=True)
         return
     user_input = match.group(1)
     await opinion(update, context, user_input, [], None)
@@ -36,7 +36,7 @@ async def handle_opinion_of(update: Update, context: CallbackContext):
             user_id = update.message.reply_to_message.from_user.id
             user_input = match.group(1)
         else:
-            await update.message.reply_text("Первым параметром идет имя человека, а потом топик, про который хочешь узнать мнение. Ничему тебя в школе не учили?", quote=True)
+            await update.message.reply_text("Первым параметром идет имя человека, а потом топик, про который хочешь узнать мнение. Ничему тебя в школе не учили?", do_quote=True)
             return
     else:
         user_name = match.group(1)
@@ -52,11 +52,11 @@ async def handle_opinion_of(update: Update, context: CallbackContext):
         kansou = random.choice(["Хмм...", "Нуу...", "", "Эээ...", "🤔"])
         results = [("Да ничего я не думаю об этом ._.", 25), ("Да мне как-то все равно...", 25), ("Думаю это супер! ❤️", 80), ("It's ok I guess...", 60), ("Мне нравится!", 100), ("Крутая вещь! 🔥", 30), ("Мне не очень нравится...", 80), ("Такое себе...", 30), ("Это моя самая любимая вещь! 🔥", 10), ("Я ненавижу это! 😡", 10), ("Это худшее, что когда либо было изобретено человечеством", 1),  ("Эта самая лучшая вещь во вселенной!", 1),]
         res = my_random.choices([x for x, w in results], weights=[w for x, w in results])[0]
-        await update.message.reply_text(f"{intro} {kansou}\n{res}", quote=False)
+        await update.message.reply_text(f"{intro} {kansou}\n{res}", do_quote=False)
         return
 
     if user_id is None:
-        await update.message.reply_text(f"\"{user_name}\"? Не припоминаю таких", quote=True)
+        await update.message.reply_text(f"\"{user_name}\"? Не припоминаю таких", do_quote=True)
         return
     await opinion(update, context, user_input, [], user_id)
 
@@ -103,18 +103,18 @@ async def opinion(update: Update, context: CallbackContext, user_input, previous
 
     if result is None:
         if len(previous_results) > 0 and from_user_id is None:
-            await update.message.reply_text(f"Я уже все высказал, что я думаю о \"{user_input}\"", quote=False)
+            await update.message.reply_text(f"Я уже все высказал, что я думаю о \"{user_input}\"", do_quote=False)
         elif len(previous_results) > 0 and from_user_id is not None:
-            await update.message.reply_text(f"Я уже все передал, что {redis_db.get_username_by_id(from_user_id)} думает о \"{user_input}\"", quote=False)
+            await update.message.reply_text(f"Я уже все передал, что {redis_db.get_username_by_id(from_user_id)} думает о \"{user_input}\"", do_quote=False)
         elif from_user_id is not None:
-            await update.message.reply_text(f"Кажется {redis_db.get_username_by_id(from_user_id)} ничего не думает о \"{user_input}\" x_x", quote=False)
+            await update.message.reply_text(f"Кажется {redis_db.get_username_by_id(from_user_id)} ничего не думает о \"{user_input}\" x_x", do_quote=False)
         else:
-            await update.message.reply_text(f"Я ничего не знаю о \"{user_input}\" >_<", quote=False)
+            await update.message.reply_text(f"Я ничего не знаю о \"{user_input}\" >_<", do_quote=False)
         return
     
     if again_setter:
         again_setter(lambda: opinion(update, context, user_input, previous_results + [result.lower()], from_user_id))
-    await update.message.reply_text(result, quote=False)
+    await update.message.reply_text(result, do_quote=False)
 
 
 def subscribe(u: Updater, _again_setter):

--- a/opinion.py
+++ b/opinion.py
@@ -5,7 +5,7 @@ from telegram.ext import Application, CallbackContext, CommandHandler
 import re
 import random
 import redis_db
-from utils import in_whitelist, parse_userid
+from utils import parse_userid
 
 r = redis_db.connect()
 logger = logging.getLogger(__name__)
@@ -14,8 +14,6 @@ ENDINGS_REGEX = re.compile(r"(?:ах|а|ев|ей|е|ов|о|иях|ия|ие|и
 
 
 async def handle_opinion(update: Update, context: CallbackContext):
-    if (not in_whitelist(update)):
-        return
     logger.info(f"[opinion] {update.message.text}")
     match = re.match(r'/[\S]+\s+(.+)', update.message.text)
     if match is None:
@@ -26,8 +24,6 @@ async def handle_opinion(update: Update, context: CallbackContext):
 
 
 async def handle_opinion_of(update: Update, context: CallbackContext):
-    if (not in_whitelist(update)):
-        return
     logger.info(f"[opinionof] {update.message.text}")
     match = re.match(r'/[\S]+\s+([\S]+)\s+(.+)', update.message.text, re.DOTALL)
     if match is None:

--- a/party.py
+++ b/party.py
@@ -1,7 +1,6 @@
 from telegram import Update, InlineKeyboardMarkup, InlineKeyboardButton
 from telegram.ext import Application, CallbackContext, CommandHandler, CallbackQueryHandler
 import redis_db
-from utils import in_whitelist
 from datetime import datetime, timedelta, time
 import logging
 import re
@@ -19,8 +18,6 @@ LAST_TOUCHED_DATETIME = "last_touched_date"
 MAX_PEOPLE_IN_PARTY = 10
 
 async def party_create(update: Update, context: CallbackContext):
-    if not in_whitelist(update):
-        return
     logger.info('[party_create]')
 
     match = re.match(r'/[\S]+\s+(.+)\s+([0-9]+)', update.message.text)
@@ -51,8 +48,6 @@ async def party_create(update: Update, context: CallbackContext):
     await update.message.reply_text(f"Команда для игры в {game_name} создана.\nЖду, пока наберется {people_count} человек и пингую", do_quote=False)
 
 async def party_list(update: Update, context: CallbackContext):
-    if not in_whitelist(update):
-        return
     logger.info('[party_list]')
 
     parties = r.hgetall(PARTIES)
@@ -71,8 +66,6 @@ async def party_list(update: Update, context: CallbackContext):
     await update.message.reply_text(reply_text, do_quote=False)
 
 async def party_join(update: Update, context: CallbackContext):
-    if not in_whitelist(update):
-        return
     logger.info('[party_join]')
 
     game_name = await get_game_name_from_msg_if_exists_or_send_error_reply(update)
@@ -84,8 +77,6 @@ async def party_join(update: Update, context: CallbackContext):
 
 
 async def party_delete(update: Update, context: CallbackContext):
-    if not in_whitelist(update):
-        return
     logger.info('[party_delete]')
 
     game_name = await get_game_name_from_msg_if_exists_or_send_error_reply(update)
@@ -98,8 +89,6 @@ async def party_delete(update: Update, context: CallbackContext):
     await update.message.reply_text(f"Пати для {game_name} удалена... Довольны?", do_quote=False)
 
 async def party_ping_unregister(update: Update, context: CallbackContext):
-    if not in_whitelist(update):
-        return
     logger.info('[party_ping_unregister]')
 
     game_name = await get_game_name_from_msg_if_exists_or_send_error_reply(update)
@@ -122,8 +111,6 @@ async def party_ping_unregister(update: Update, context: CallbackContext):
     await update.message.reply_text(f"Ты больше не будешь получать уведомления о пати для {game_name}... Пока снова не зайдешь в пати", do_quote=False)
 
 async def party_leave(update: Update, context: CallbackContext):
-    if not in_whitelist(update):
-        return
     logger.info('[party_leave]')
 
     game_name = await get_game_name_from_msg_if_exists_or_send_error_reply(update)
@@ -148,8 +135,6 @@ async def party_leave(update: Update, context: CallbackContext):
 
 
 async def party_ping_invite(update: Update, context: CallbackContext):
-    if not in_whitelist(update):
-        return
     logger.info('[party_ping_invite]')
 
     game_name = await get_game_name_from_msg_if_exists_or_send_error_reply(update)
@@ -174,8 +159,6 @@ async def party_ping_invite(update: Update, context: CallbackContext):
 
 
 async def party_ping(update: Update, context: CallbackContext):
-    if not in_whitelist(update):
-        return
     logger.info('[party_ping]')
 
     game_name = await get_game_name_from_msg_if_exists_or_send_error_reply(update)
@@ -194,8 +177,6 @@ async def party_ping(update: Update, context: CallbackContext):
 
 
 async def party_info(update: Update, context: CallbackContext):
-    if not in_whitelist(update):
-        return
     logger.info('[party_info]')
 
     game_name = await get_game_name_from_msg_if_exists_or_send_error_reply(update)

--- a/party.py
+++ b/party.py
@@ -18,23 +18,23 @@ NOTIFICATIONS_RECEIVERS = "notifications_receivers"
 LAST_TOUCHED_DATETIME = "last_touched_date"
 MAX_PEOPLE_IN_PARTY = 10
 
-def party_create(update: Update, context):
+async def party_create(update: Update, context: CallbackContext):
     if not in_whitelist(update):
         return
     logger.info('[party_create]')
 
     match = re.match(r'/[\S]+\s+(.+)\s+([0-9]+)', update.message.text)
     if (match == None):
-        update.message.reply_text("Дедушка тебя не понимает", quote=False)
+        await update.message.reply_text("Дедушка тебя не понимает", quote=False)
         return
     else:
         game_name = match.group(1)
         people_count = int(match.group(2))
         if (people_count == 0):
-            update.message.reply_text("Приколист дохуя?", quote=False)
+            await update.message.reply_text("Приколист дохуя?", quote=False)
             return
         if (people_count > MAX_PEOPLE_IN_PARTY):
-            update.message.reply_text("Зачем столько людей? Поставь нормальное число", quote=False)
+            await update.message.reply_text("Зачем столько людей? Поставь нормальное число", quote=False)
             return
 
     logger.info(f'[party_create] {game_name} {people_count}')
@@ -44,20 +44,20 @@ def party_create(update: Update, context):
 
     already_exists = r.hexists(PARTIES, game_name)
     if already_exists:
-        update.message.reply_text("Такая пати уже есть", quote=False)
+        await update.message.reply_text("Такая пати уже есть", quote=False)
         return
 
     save_party(game_name, new_party)
-    update.message.reply_text(f"Команда для игры в {game_name} создана.\nЖду, пока наберется {people_count} человек и пингую", quote=False)
+    await update.message.reply_text(f"Команда для игры в {game_name} создана.\nЖду, пока наберется {people_count} человек и пингую", quote=False)
 
-def party_list(update: Update, context):
+async def party_list(update: Update, context: CallbackContext):
     if not in_whitelist(update):
         return
     logger.info('[party_list]')
 
     parties = r.hgetall(PARTIES)
     if len(parties.keys()) == 0:
-        update.message.reply_text("Пати нет... Но ты можешь их создать командой /partycreate!", quote=False)
+        await update.message.reply_text("Пати нет... Но ты можешь их создать командой /partycreate!", quote=False)
         return
     reply_text = "Список всех пати:\n"
     for game_name, party_json in parties.items():
@@ -68,41 +68,41 @@ def party_list(update: Update, context):
         reply_text = reply_text + f"{game_name} - {cur_people_count}/{required_people_count}"
         reply_text = reply_text + "\n"
 
-    update.message.reply_text(reply_text, quote=False)
+    await update.message.reply_text(reply_text, quote=False)
 
-def party_join(update: Update, context):
+async def party_join(update: Update, context: CallbackContext):
     if not in_whitelist(update):
         return
     logger.info('[party_join]')
 
-    game_name = get_game_name_from_msg_if_exists_or_send_error_reply(update)
+    game_name = await get_game_name_from_msg_if_exists_or_send_error_reply(update)
     if game_name is None:
         return
 
     logger.info(f'[party_join] {game_name}')
-    join_party(game_name, update.message.from_user.id, update, False)
+    await join_party(game_name, update.message.from_user.id, update, False)
 
 
-def party_delete(update: Update, context):
+async def party_delete(update: Update, context: CallbackContext):
     if not in_whitelist(update):
         return
     logger.info('[party_delete]')
 
-    game_name = get_game_name_from_msg_if_exists_or_send_error_reply(update)
+    game_name = await get_game_name_from_msg_if_exists_or_send_error_reply(update)
     if game_name is None:
         return
 
     logger.info(f'[party_delete] {game_name}')
 
     party_json = r.hdel(PARTIES, game_name)
-    update.message.reply_text(f"Пати для {game_name} удалена... Довольны?", quote=False)
+    await update.message.reply_text(f"Пати для {game_name} удалена... Довольны?", quote=False)
 
-def party_ping_unregister(update: Update, context):
+async def party_ping_unregister(update: Update, context: CallbackContext):
     if not in_whitelist(update):
         return
     logger.info('[party_ping_unregister]')
 
-    game_name = get_game_name_from_msg_if_exists_or_send_error_reply(update)
+    game_name = await get_game_name_from_msg_if_exists_or_send_error_reply(update)
     if game_name is None:
         return
 
@@ -112,21 +112,21 @@ def party_ping_unregister(update: Update, context):
     party = daily_party_reset_if_needed(game_name, party)
     user_id = update.message.from_user.id
     if user_id not in party[NOTIFICATIONS_RECEIVERS]:
-        update.message.reply_text(f"Ты и так не получаешь уведомления {game_name} пати", quote=False)
+        await update.message.reply_text(f"Ты и так не получаешь уведомления {game_name} пати", quote=False)
         return
     else:
         party[NOTIFICATIONS_RECEIVERS].remove(user_id)
 
 
     save_party(game_name, party)
-    update.message.reply_text(f"Ты больше не будешь получать уведомления о пати для {game_name}... Пока снова не зайдешь в пати", quote=False)
+    await update.message.reply_text(f"Ты больше не будешь получать уведомления о пати для {game_name}... Пока снова не зайдешь в пати", quote=False)
 
-def party_leave(update: Update, context):
+async def party_leave(update: Update, context: CallbackContext):
     if not in_whitelist(update):
         return
     logger.info('[party_leave]')
 
-    game_name = get_game_name_from_msg_if_exists_or_send_error_reply(update)
+    game_name = await get_game_name_from_msg_if_exists_or_send_error_reply(update)
     if game_name is None:
         return
 
@@ -136,7 +136,7 @@ def party_leave(update: Update, context):
     party = daily_party_reset_if_needed(game_name, party)
     user_id = update.message.from_user.id
     if user_id not in party[CUR_PEOPLE_JOINED]:
-        update.message.reply_text(f"Ты и так не в пати", quote=False)
+        await update.message.reply_text(f"Ты и так не в пати", quote=False)
         return
     else:
         party[CUR_PEOPLE_JOINED].remove(user_id)
@@ -144,15 +144,15 @@ def party_leave(update: Update, context):
     save_party(game_name, party)
     cur_people_joined_count = len(party[CUR_PEOPLE_JOINED])
     required_people_count = party[REQUIRED_PEOPLE_COUNT]
-    update.message.reply_text(f"Ты ливнул из пати для {game_name}...\nТеперь в пати {cur_people_joined_count}/{required_people_count} челов", quote=False)
+    await update.message.reply_text(f"Ты ливнул из пати для {game_name}...\nТеперь в пати {cur_people_joined_count}/{required_people_count} челов", quote=False)
 
 
-def party_ping_invite(update: Update, context):
+async def party_ping_invite(update: Update, context: CallbackContext):
     if not in_whitelist(update):
         return
     logger.info('[party_ping_invite]')
 
-    game_name = get_game_name_from_msg_if_exists_or_send_error_reply(update)
+    game_name = await get_game_name_from_msg_if_exists_or_send_error_reply(update)
     if game_name is None:
         return
 
@@ -164,21 +164,21 @@ def party_ping_invite(update: Update, context):
     notifications_receivers = party[NOTIFICATIONS_RECEIVERS]
     regular_players_that_are_not_joined = list(set(notifications_receivers) - set(cur_people_joined))
     if len(regular_players_that_are_not_joined) == 0:
-        update.message.reply_text(f"Никого не забыли, абсолютно все сейчас в пати {game_name}!", quote=False)
+        await update.message.reply_text(f"Никого не забыли, абсолютно все сейчас в пати {game_name}!", quote=False)
         return
     reply_text = f"Пингую всех, кто когда либо был в {game_name} пати, но сейчас не джойнут\n"
     reply_text += ', '.join([f"@{redis_db.get_username_by_id(id)}" for id in regular_players_that_are_not_joined])
     reply_text += f"\n\nЕсли ты не хочешь быть в этом списке, юзай /partypingunregister"
 
-    update.message.reply_text(reply_text, quote=False)
+    await update.message.reply_text(reply_text, quote=False)
 
 
-def party_ping(update: Update, context):
+async def party_ping(update: Update, context: CallbackContext):
     if not in_whitelist(update):
         return
     logger.info('[party_ping]')
 
-    game_name = get_game_name_from_msg_if_exists_or_send_error_reply(update)
+    game_name = await get_game_name_from_msg_if_exists_or_send_error_reply(update)
     if game_name is None:
         return
 
@@ -190,15 +190,15 @@ def party_ping(update: Update, context):
     reply_text = f"{game_name}\n"
     reply_text += ', '.join([f"@{redis_db.get_username_by_id(id)}" for id in cur_people_joined])
 
-    update.message.reply_text(reply_text, quote=False)
+    await update.message.reply_text(reply_text, quote=False)
 
 
-def party_info(update: Update, context):
+async def party_info(update: Update, context: CallbackContext):
     if not in_whitelist(update):
         return
     logger.info('[party_info]')
 
-    game_name = get_game_name_from_msg_if_exists_or_send_error_reply(update)
+    game_name = await get_game_name_from_msg_if_exists_or_send_error_reply(update)
     if (game_name == None):
         return
 
@@ -225,20 +225,20 @@ def party_info(update: Update, context):
             reply_text = reply_text + f"\n\nРаньше играли, а щас отлынивают: "
             reply_text += ', '.join([redis_db.get_username_by_id(id) for id in regular_players_that_are_not_joined])
 
-    update.message.reply_text(reply_text, quote=False)
+    await update.message.reply_text(reply_text, quote=False)
 
 
-def on_join_button_press(update: Update, ctx):
+async def on_join_button_press(update: Update, ctx):
     query = update.callback_query
     # Not checking for whitelist because its broken with callback query...
     
     game_name = query.data[len("join_party "):]
     if not r.hexists(PARTIES, game_name):
-        query.answer()
+        await query.answer()
         return
     
-    query.answer(f"Добавил тебя в пати {game_name}")
-    join_party(game_name, query.from_user.id, update, True)
+    await query.answer(f"Добавил тебя в пати {game_name}")
+    await join_party(game_name, query.from_user.id, update, True)
 
 
 
@@ -258,16 +258,16 @@ def subscribe(u: Updater):
 
 
 # ----------------- Helpers functions for readability ---------------
-def get_game_name_from_msg_if_exists_or_send_error_reply(update: Update) -> Optional[str]:
+async def get_game_name_from_msg_if_exists_or_send_error_reply(update: Update) -> Optional[str]:
     match = re.match(r'/[\S]+\s+(.+)', update.message.text)
     if (match == None):
-        update.message.reply_text("Не понял", quote=False)
+        await update.message.reply_text("Не понял", quote=False)
         return None
     else:
         game_name = match.group(1)
 
     if not r.hexists(PARTIES, game_name):
-        update.message.reply_text("Нет такой пати", quote=False)
+        await update.message.reply_text("Нет такой пати", quote=False)
         return None
 
     return game_name
@@ -316,7 +316,7 @@ def add_join_button(game_name: str):
     markup = InlineKeyboardMarkup(keyboard)
     return markup
 
-def join_party(game_name: str, user_id: int, update: Update, from_query: bool):
+async def join_party(game_name: str, user_id: int, update: Update, from_query: bool):
     party = load_party(game_name)
     party = daily_party_reset_if_needed(game_name, party)
     required_people_count = party[REQUIRED_PEOPLE_COUNT]
@@ -325,7 +325,7 @@ def join_party(game_name: str, user_id: int, update: Update, from_query: bool):
         party[CUR_PEOPLE_JOINED].append(user_id)
     else:
         if not from_query:
-            update.message.reply_text(f"Ты уже в пати {game_name} ({len(party[CUR_PEOPLE_JOINED])}/{party[REQUIRED_PEOPLE_COUNT]})", quote=False, reply_markup = add_join_button(game_name))
+            await update.message.reply_text(f"Ты уже в пати {game_name} ({len(party[CUR_PEOPLE_JOINED])}/{party[REQUIRED_PEOPLE_COUNT]})", quote=False, reply_markup = add_join_button(game_name))
         return
 
     if user_id not in party[NOTIFICATIONS_RECEIVERS]:
@@ -338,22 +338,22 @@ def join_party(game_name: str, user_id: int, update: Update, from_query: bool):
         reply_text = f"Пати для {game_name} ({len(party[CUR_PEOPLE_JOINED])}/{party[REQUIRED_PEOPLE_COUNT]}) набралась!\n"
         reply_text += ', '.join([f"@{redis_db.get_username_by_id(id)}" for id in party[CUR_PEOPLE_JOINED]])
         if from_query:
-            update.callback_query.edit_message_text(reply_text, reply_markup = add_join_button(game_name))
-            update.callback_query.message.reply_text(reply_text, quote=False)
+            await update.callback_query.edit_message_text(reply_text, reply_markup = add_join_button(game_name))
+            await update.callback_query.message.reply_text(reply_text, quote=False)
         else:
-            update.message.reply_text(reply_text, quote=False)
+            await update.message.reply_text(reply_text, quote=False)
 
     elif cur_people_count > required_people_count:
         reply_text = f"Людей для {game_name} ({len(party[CUR_PEOPLE_JOINED])}/{party[REQUIRED_PEOPLE_COUNT]}) уже больше чем нужно. Жесть!\n"
         reply_text += ', '.join([redis_db.get_username_by_id(id) for id in party[CUR_PEOPLE_JOINED]])
         if from_query:
-            update.callback_query.edit_message_text(reply_text, reply_markup = add_join_button(game_name))
+            await update.callback_query.edit_message_text(reply_text, reply_markup = add_join_button(game_name))
         else:
-            update.message.reply_text(reply_text, quote=False)
+            await update.message.reply_text(reply_text, quote=False)
 
     elif cur_people_count < required_people_count:
         reply_text = f"Ты зашел в пати {game_name} ({len(party[CUR_PEOPLE_JOINED])}/{party[REQUIRED_PEOPLE_COUNT]})!"
         if from_query:
-            update.callback_query.edit_message_text(reply_text, reply_markup = add_join_button(game_name))
+            await update.callback_query.edit_message_text(reply_text, reply_markup = add_join_button(game_name))
         else:
-            update.message.reply_text(reply_text, quote=False, reply_markup = add_join_button(game_name))
+            await update.message.reply_text(reply_text, quote=False, reply_markup = add_join_button(game_name))

--- a/party.py
+++ b/party.py
@@ -1,5 +1,5 @@
-from telegram import ParseMode, Update, InlineKeyboardMarkup, InlineKeyboardButton
-from telegram.ext import Updater, CommandHandler, CallbackQueryHandler
+from telegram import Update, InlineKeyboardMarkup, InlineKeyboardButton
+from telegram.ext import Application, CallbackContext, CommandHandler, CallbackQueryHandler
 import redis_db
 from utils import in_whitelist
 from datetime import datetime, timedelta, time
@@ -244,17 +244,17 @@ async def on_join_button_press(update: Update, ctx):
 
 # Ideally there needs to be 1 common handler for all commands that incapsulates parsing message, whitelisting, daily reset
 #  and other non-command-related stuff.
-def subscribe(u: Updater):
-    u.dispatcher.add_handler(CommandHandler("partycreate", party_create))
-    u.dispatcher.add_handler(CommandHandler("partylist", party_list))
-    u.dispatcher.add_handler(CommandHandler(("party", "partyjoin"), party_join))
-    u.dispatcher.add_handler(CommandHandler("partydelete", party_delete)) #not tested
-    u.dispatcher.add_handler(CommandHandler("partypingunregister", party_ping_unregister)) #not tested
-    u.dispatcher.add_handler(CommandHandler("partyleave", party_leave)) #not tested
-    u.dispatcher.add_handler(CommandHandler("partyping", party_ping)) #not tested
-    u.dispatcher.add_handler(CommandHandler("partypinginvite", party_ping_invite)) #not tested
-    u.dispatcher.add_handler(CommandHandler("partyinfo", party_info)) #not tested
-    u.dispatcher.add_handler(CallbackQueryHandler(on_join_button_press, pattern="^join_party"))
+def subscribe(a: Application):
+    a.add_handler(CommandHandler("partycreate", party_create))
+    a.add_handler(CommandHandler("partylist", party_list))
+    a.add_handler(CommandHandler(("party", "partyjoin"), party_join))
+    a.add_handler(CommandHandler("partydelete", party_delete)) #not tested
+    a.add_handler(CommandHandler("partypingunregister", party_ping_unregister)) #not tested
+    a.add_handler(CommandHandler("partyleave", party_leave)) #not tested
+    a.add_handler(CommandHandler("partyping", party_ping)) #not tested
+    a.add_handler(CommandHandler("partypinginvite", party_ping_invite)) #not tested
+    a.add_handler(CommandHandler("partyinfo", party_info)) #not tested
+    a.add_handler(CallbackQueryHandler(on_join_button_press, pattern="^join_party"))
 
 
 # ----------------- Helpers functions for readability ---------------

--- a/party.py
+++ b/party.py
@@ -25,16 +25,16 @@ async def party_create(update: Update, context: CallbackContext):
 
     match = re.match(r'/[\S]+\s+(.+)\s+([0-9]+)', update.message.text)
     if (match == None):
-        await update.message.reply_text("Дедушка тебя не понимает", quote=False)
+        await update.message.reply_text("Дедушка тебя не понимает", do_quote=False)
         return
     else:
         game_name = match.group(1)
         people_count = int(match.group(2))
         if (people_count == 0):
-            await update.message.reply_text("Приколист дохуя?", quote=False)
+            await update.message.reply_text("Приколист дохуя?", do_quote=False)
             return
         if (people_count > MAX_PEOPLE_IN_PARTY):
-            await update.message.reply_text("Зачем столько людей? Поставь нормальное число", quote=False)
+            await update.message.reply_text("Зачем столько людей? Поставь нормальное число", do_quote=False)
             return
 
     logger.info(f'[party_create] {game_name} {people_count}')
@@ -44,11 +44,11 @@ async def party_create(update: Update, context: CallbackContext):
 
     already_exists = r.hexists(PARTIES, game_name)
     if already_exists:
-        await update.message.reply_text("Такая пати уже есть", quote=False)
+        await update.message.reply_text("Такая пати уже есть", do_quote=False)
         return
 
     save_party(game_name, new_party)
-    await update.message.reply_text(f"Команда для игры в {game_name} создана.\nЖду, пока наберется {people_count} человек и пингую", quote=False)
+    await update.message.reply_text(f"Команда для игры в {game_name} создана.\nЖду, пока наберется {people_count} человек и пингую", do_quote=False)
 
 async def party_list(update: Update, context: CallbackContext):
     if not in_whitelist(update):
@@ -57,7 +57,7 @@ async def party_list(update: Update, context: CallbackContext):
 
     parties = r.hgetall(PARTIES)
     if len(parties.keys()) == 0:
-        await update.message.reply_text("Пати нет... Но ты можешь их создать командой /partycreate!", quote=False)
+        await update.message.reply_text("Пати нет... Но ты можешь их создать командой /partycreate!", do_quote=False)
         return
     reply_text = "Список всех пати:\n"
     for game_name, party_json in parties.items():
@@ -68,7 +68,7 @@ async def party_list(update: Update, context: CallbackContext):
         reply_text = reply_text + f"{game_name} - {cur_people_count}/{required_people_count}"
         reply_text = reply_text + "\n"
 
-    await update.message.reply_text(reply_text, quote=False)
+    await update.message.reply_text(reply_text, do_quote=False)
 
 async def party_join(update: Update, context: CallbackContext):
     if not in_whitelist(update):
@@ -95,7 +95,7 @@ async def party_delete(update: Update, context: CallbackContext):
     logger.info(f'[party_delete] {game_name}')
 
     party_json = r.hdel(PARTIES, game_name)
-    await update.message.reply_text(f"Пати для {game_name} удалена... Довольны?", quote=False)
+    await update.message.reply_text(f"Пати для {game_name} удалена... Довольны?", do_quote=False)
 
 async def party_ping_unregister(update: Update, context: CallbackContext):
     if not in_whitelist(update):
@@ -112,14 +112,14 @@ async def party_ping_unregister(update: Update, context: CallbackContext):
     party = daily_party_reset_if_needed(game_name, party)
     user_id = update.message.from_user.id
     if user_id not in party[NOTIFICATIONS_RECEIVERS]:
-        await update.message.reply_text(f"Ты и так не получаешь уведомления {game_name} пати", quote=False)
+        await update.message.reply_text(f"Ты и так не получаешь уведомления {game_name} пати", do_quote=False)
         return
     else:
         party[NOTIFICATIONS_RECEIVERS].remove(user_id)
 
 
     save_party(game_name, party)
-    await update.message.reply_text(f"Ты больше не будешь получать уведомления о пати для {game_name}... Пока снова не зайдешь в пати", quote=False)
+    await update.message.reply_text(f"Ты больше не будешь получать уведомления о пати для {game_name}... Пока снова не зайдешь в пати", do_quote=False)
 
 async def party_leave(update: Update, context: CallbackContext):
     if not in_whitelist(update):
@@ -136,7 +136,7 @@ async def party_leave(update: Update, context: CallbackContext):
     party = daily_party_reset_if_needed(game_name, party)
     user_id = update.message.from_user.id
     if user_id not in party[CUR_PEOPLE_JOINED]:
-        await update.message.reply_text(f"Ты и так не в пати", quote=False)
+        await update.message.reply_text(f"Ты и так не в пати", do_quote=False)
         return
     else:
         party[CUR_PEOPLE_JOINED].remove(user_id)
@@ -144,7 +144,7 @@ async def party_leave(update: Update, context: CallbackContext):
     save_party(game_name, party)
     cur_people_joined_count = len(party[CUR_PEOPLE_JOINED])
     required_people_count = party[REQUIRED_PEOPLE_COUNT]
-    await update.message.reply_text(f"Ты ливнул из пати для {game_name}...\nТеперь в пати {cur_people_joined_count}/{required_people_count} челов", quote=False)
+    await update.message.reply_text(f"Ты ливнул из пати для {game_name}...\nТеперь в пати {cur_people_joined_count}/{required_people_count} челов", do_quote=False)
 
 
 async def party_ping_invite(update: Update, context: CallbackContext):
@@ -164,13 +164,13 @@ async def party_ping_invite(update: Update, context: CallbackContext):
     notifications_receivers = party[NOTIFICATIONS_RECEIVERS]
     regular_players_that_are_not_joined = list(set(notifications_receivers) - set(cur_people_joined))
     if len(regular_players_that_are_not_joined) == 0:
-        await update.message.reply_text(f"Никого не забыли, абсолютно все сейчас в пати {game_name}!", quote=False)
+        await update.message.reply_text(f"Никого не забыли, абсолютно все сейчас в пати {game_name}!", do_quote=False)
         return
     reply_text = f"Пингую всех, кто когда либо был в {game_name} пати, но сейчас не джойнут\n"
     reply_text += ', '.join([f"@{redis_db.get_username_by_id(id)}" for id in regular_players_that_are_not_joined])
     reply_text += f"\n\nЕсли ты не хочешь быть в этом списке, юзай /partypingunregister"
 
-    await update.message.reply_text(reply_text, quote=False)
+    await update.message.reply_text(reply_text, do_quote=False)
 
 
 async def party_ping(update: Update, context: CallbackContext):
@@ -190,7 +190,7 @@ async def party_ping(update: Update, context: CallbackContext):
     reply_text = f"{game_name}\n"
     reply_text += ', '.join([f"@{redis_db.get_username_by_id(id)}" for id in cur_people_joined])
 
-    await update.message.reply_text(reply_text, quote=False)
+    await update.message.reply_text(reply_text, do_quote=False)
 
 
 async def party_info(update: Update, context: CallbackContext):
@@ -225,7 +225,7 @@ async def party_info(update: Update, context: CallbackContext):
             reply_text = reply_text + f"\n\nРаньше играли, а щас отлынивают: "
             reply_text += ', '.join([redis_db.get_username_by_id(id) for id in regular_players_that_are_not_joined])
 
-    await update.message.reply_text(reply_text, quote=False)
+    await update.message.reply_text(reply_text, do_quote=False)
 
 
 async def on_join_button_press(update: Update, ctx):
@@ -261,13 +261,13 @@ def subscribe(u: Updater):
 async def get_game_name_from_msg_if_exists_or_send_error_reply(update: Update) -> Optional[str]:
     match = re.match(r'/[\S]+\s+(.+)', update.message.text)
     if (match == None):
-        await update.message.reply_text("Не понял", quote=False)
+        await update.message.reply_text("Не понял", do_quote=False)
         return None
     else:
         game_name = match.group(1)
 
     if not r.hexists(PARTIES, game_name):
-        await update.message.reply_text("Нет такой пати", quote=False)
+        await update.message.reply_text("Нет такой пати", do_quote=False)
         return None
 
     return game_name
@@ -325,7 +325,7 @@ async def join_party(game_name: str, user_id: int, update: Update, from_query: b
         party[CUR_PEOPLE_JOINED].append(user_id)
     else:
         if not from_query:
-            await update.message.reply_text(f"Ты уже в пати {game_name} ({len(party[CUR_PEOPLE_JOINED])}/{party[REQUIRED_PEOPLE_COUNT]})", quote=False, reply_markup = add_join_button(game_name))
+            await update.message.reply_text(f"Ты уже в пати {game_name} ({len(party[CUR_PEOPLE_JOINED])}/{party[REQUIRED_PEOPLE_COUNT]})", do_quote=False, reply_markup = add_join_button(game_name))
         return
 
     if user_id not in party[NOTIFICATIONS_RECEIVERS]:
@@ -339,9 +339,9 @@ async def join_party(game_name: str, user_id: int, update: Update, from_query: b
         reply_text += ', '.join([f"@{redis_db.get_username_by_id(id)}" for id in party[CUR_PEOPLE_JOINED]])
         if from_query:
             await update.callback_query.edit_message_text(reply_text, reply_markup = add_join_button(game_name))
-            await update.callback_query.message.reply_text(reply_text, quote=False)
+            await update.callback_query.message.reply_text(reply_text, do_quote=False)
         else:
-            await update.message.reply_text(reply_text, quote=False)
+            await update.message.reply_text(reply_text, do_quote=False)
 
     elif cur_people_count > required_people_count:
         reply_text = f"Людей для {game_name} ({len(party[CUR_PEOPLE_JOINED])}/{party[REQUIRED_PEOPLE_COUNT]}) уже больше чем нужно. Жесть!\n"
@@ -349,11 +349,11 @@ async def join_party(game_name: str, user_id: int, update: Update, from_query: b
         if from_query:
             await update.callback_query.edit_message_text(reply_text, reply_markup = add_join_button(game_name))
         else:
-            await update.message.reply_text(reply_text, quote=False)
+            await update.message.reply_text(reply_text, do_quote=False)
 
     elif cur_people_count < required_people_count:
         reply_text = f"Ты зашел в пати {game_name} ({len(party[CUR_PEOPLE_JOINED])}/{party[REQUIRED_PEOPLE_COUNT]})!"
         if from_query:
             await update.callback_query.edit_message_text(reply_text, reply_markup = add_join_button(game_name))
         else:
-            await update.message.reply_text(reply_text, quote=False, reply_markup = add_join_button(game_name))
+            await update.message.reply_text(reply_text, do_quote=False, reply_markup = add_join_button(game_name))

--- a/random_cope.py
+++ b/random_cope.py
@@ -19,76 +19,76 @@ async def random_cope(update: Update, context: CallbackContext):
     res = random.choices(options, weights=weights)[0]
     logger.info(f"[cope] res {res}")
     if res == 1:
-        await update.message.reply_text(f"Найс коупишь", quote=False)
+        await update.message.reply_text(f"Найс коупишь", do_quote=False)
     elif res == 2:
-        await update.message.reply_text(f"Коуп жиденький", quote=False)
+        await update.message.reply_text(f"Коуп жиденький", do_quote=False)
     elif res == 3:
-        await update.message.reply_text(f"Коуп хороший\nЗдорово покоупил", quote=False)
+        await update.message.reply_text(f"Коуп хороший\nЗдорово покоупил", do_quote=False)
     elif res == 4:
-        await update.message.reply_text(f"Коуп плохой\nКоупи лучше", quote=False)
+        await update.message.reply_text(f"Коуп плохой\nКоупи лучше", do_quote=False)
     elif res == 5:
-        await update.message.reply_text(f"Коуп отвратительный", quote=False)
+        await update.message.reply_text(f"Коуп отвратительный", do_quote=False)
     elif res == 6:
-        await update.message.reply_text(f"=== ЛЕГЕНДАРНЫЙ КОУП ===\nЭтот коуп войдет в историю!\nПоздравляем @{update.message.from_user.username} с получением этого невероятного редкого коупа", quote=False)
+        await update.message.reply_text(f"=== ЛЕГЕНДАРНЫЙ КОУП ===\nЭтот коуп войдет в историю!\nПоздравляем @{update.message.from_user.username} с получением этого невероятного редкого коупа", do_quote=False)
     elif res == 7:
-        await update.message.reply_text(f"Коуп слабый\nКоупи сильнее", quote=False)
+        await update.message.reply_text(f"Коуп слабый\nКоупи сильнее", do_quote=False)
     elif res == 8:
-        await update.message.reply_text(f"Тариф Гигакоупище\nБезлимитный коуп по всей России", quote=False)
+        await update.message.reply_text(f"Тариф Гигакоупище\nБезлимитный коуп по всей России", do_quote=False)
     elif res == 9:
-        await update.message.reply_text(f"Лютейший коуп", quote=False)
+        await update.message.reply_text(f"Лютейший коуп", do_quote=False)
     elif res == 10:
-        await update.message.reply_text(f"Удачный коуп!\nМожешь еще раз покоупить", quote=False)
+        await update.message.reply_text(f"Удачный коуп!\nМожешь еще раз покоупить", do_quote=False)
     elif res == 11:
-        await update.message.reply_text(f"Этот божественный коуп настолько силен, что способен излучать ауру добра и позитива, которая увеличивает силу коупа друзей на 50%", quote=False)
+        await update.message.reply_text(f"Этот божественный коуп настолько силен, что способен излучать ауру добра и позитива, которая увеличивает силу коупа друзей на 50%", do_quote=False)
     elif res == 12:
-        await update.message.reply_text(f"Выбираем главного коупера дня", quote=False)
+        await update.message.reply_text(f"Выбираем главного коупера дня", do_quote=False)
         sleep(1.5)
-        await update.message.reply_text(random.choice(["Хмм...", "Так-так-так...", "Расшифровываю результаты...", "Спрашиваем мнения экспертов...", "Дайте подумать..."]), quote=False)
+        await update.message.reply_text(random.choice(["Хмм...", "Так-так-так...", "Расшифровываю результаты...", "Спрашиваем мнения экспертов...", "Дайте подумать..."]), do_quote=False)
         sleep(1.5)
-        await update.message.reply_text(f"А вот и победитель - @{update.message.from_user.username}!", quote=False)
+        await update.message.reply_text(f"А вот и победитель - @{update.message.from_user.username}!", do_quote=False)
     elif res == 13:
-        await update.message.reply_text(f"Как же он сильно коупит...\nПарень полегче!", quote=False)
+        await update.message.reply_text(f"Как же он сильно коупит...\nПарень полегче!", do_quote=False)
     elif res == 14:
-        await update.message.reply_text(f"Критически плохой коуп!\nУ тебя весь день будет ФОМО", quote=False)
+        await update.message.reply_text(f"Критически плохой коуп!\nУ тебя весь день будет ФОМО", do_quote=False)
     elif res == 15:
-        await update.message.reply_text(f"Отличный коуп!\nВсе проблемы решены", quote=False)
+        await update.message.reply_text(f"Отличный коуп!\nВсе проблемы решены", do_quote=False)
     elif res == 16:
-        await update.message.reply_text(f"Шедевральный коуп!\nО нем напишут в книгах", quote=False)
+        await update.message.reply_text(f"Шедевральный коуп!\nО нем напишут в книгах", do_quote=False)
     elif res == 17:
-        await update.message.reply_text(f"Я не вижу вашего коупа", quote=False)
+        await update.message.reply_text(f"Я не вижу вашего коупа", do_quote=False)
     elif res == 18:
         values = list(r.hgetall(DICTIONARY_HASH).values())
         values = [val for val in values if val.startswith(STICKER_PREFIX)]
         if len(values) == 0:
-            await update.message.reply_animation("CgACAgQAAx0CT_IhJQABBXMmY7qlHgn9TsIE04UL3TKhfZGCmOgAAmIDAAJ43PVSPgZ0f8U9qU4tBA", quote=False)
+            await update.message.reply_animation("CgACAgQAAx0CT_IhJQABBXMmY7qlHgn9TsIE04UL3TKhfZGCmOgAAmIDAAJ43PVSPgZ0f8U9qU4tBA", do_quote=False)
             return
         random.shuffle(values)
         file_id = values[0][len(STICKER_PREFIX):]
         logger.info(f"fileid {file_id}")
-        await update.message.reply_sticker(file_id, quote=False)
+        await update.message.reply_sticker(file_id, do_quote=False)
     elif res == 19:
         values = list(r.hgetall(DICTIONARY_HASH).values())
         values = [val for val in values if val.startswith(GIF_PREFIX)]
         if len(values) == 0:
-            await update.message.reply_animation("CgACAgQAAx0CT_IhJQABBXMmY7qlHgn9TsIE04UL3TKhfZGCmOgAAmIDAAJ43PVSPgZ0f8U9qU4tBA", quote=False)
+            await update.message.reply_animation("CgACAgQAAx0CT_IhJQABBXMmY7qlHgn9TsIE04UL3TKhfZGCmOgAAmIDAAJ43PVSPgZ0f8U9qU4tBA", do_quote=False)
             return
         random.shuffle(values)
         file_id = values[0][len(GIF_PREFIX):]
         logger.info(f"fileid {file_id}")
-        await update.message.reply_animation(file_id, quote=False)
+        await update.message.reply_animation(file_id, do_quote=False)
     elif res == 20:
-        await update.message.reply_text(f"Кто-то сомневается в твоем коупе? Вызови его на дуэль в /rockpaperscissors и посмотри чей коуп победит!", quote=False)
+        await update.message.reply_text(f"Кто-то сомневается в твоем коупе? Вызови его на дуэль в /rockpaperscissors и посмотри чей коуп победит!", do_quote=False)
     elif res == 21:
-        await update.message.reply_text(f"Кто-то сомневается в твоем коупе? Вызови его на дуэль в /connectfour и посмотри чей коуп победит!", quote=False)
+        await update.message.reply_text(f"Кто-то сомневается в твоем коупе? Вызови его на дуэль в /connectfour и посмотри чей коуп победит!", do_quote=False)
     elif res == 22:
         keys = list(r.hgetall(DICTIONARY_HASH).keys())
         keys = [key for key in keys if key.lower().startswith("коуп")]
         if len(keys) == 0:
-            await update.message.reply_animation("CgACAgQAAx0CT_IhJQABBXMmY7qlHgn9TsIE04UL3TKhfZGCmOgAAmIDAAJ43PVSPgZ0f8U9qU4tBA", quote=False)
+            await update.message.reply_animation("CgACAgQAAx0CT_IhJQABBXMmY7qlHgn9TsIE04UL3TKhfZGCmOgAAmIDAAJ43PVSPgZ0f8U9qU4tBA", do_quote=False)
             return
         random.shuffle(keys)
         key = keys[0]
-        await update.message.reply_text(f"/get {key}", quote=False)
+        await update.message.reply_text(f"/get {key}", do_quote=False)
         sleep(0.5)
         logger.info(f"cope get {key}")
         update.message.text = f"/get {key}"
@@ -96,38 +96,38 @@ async def random_cope(update: Update, context: CallbackContext):
     elif res == 23:
         await opinion(update, context, "коуп")
     elif res == 24:
-        await update.message.reply_text(f"Оцениваем силу коупа от 1 до 6", quote=False)
+        await update.message.reply_text(f"Оцениваем силу коупа от 1 до 6", do_quote=False)
         sleep(0.5)
-        await update.message.reply_dice(quote=False)
+        await update.message.reply_dice(do_quote=False)
     elif res == 25:
         # Cope harder sir
-        await update.message.reply_animation("CgACAgQAAx0CT_IhJQABBXMmY7qlHgn9TsIE04UL3TKhfZGCmOgAAmIDAAJ43PVSPgZ0f8U9qU4tBA", quote=False)
+        await update.message.reply_animation("CgACAgQAAx0CT_IhJQABBXMmY7qlHgn9TsIE04UL3TKhfZGCmOgAAmIDAAJ43PVSPgZ0f8U9qU4tBA", do_quote=False)
     elif res == 26:
-        await update.message.reply_text(f"Врать не буду, коуп не впечатлил", quote=False)
+        await update.message.reply_text(f"Врать не буду, коуп не впечатлил", do_quote=False)
     elif res == 27:
-        await update.message.reply_text(f"Удовлетворительный коуп", quote=False)
+        await update.message.reply_text(f"Удовлетворительный коуп", do_quote=False)
     elif res == 28:
-        await update.message.reply_text(f"Взорванный коуп!", quote=False)
+        await update.message.reply_text(f"Взорванный коуп!", do_quote=False)
     elif res == 29:
-        await update.message.reply_text(f"Хорош коупить, погнали лучше в казиныч!\nЗаодно посмотрим насколько хорошо твой коуп сможет выбить нам 3 лимона", quote=False)
+        await update.message.reply_text(f"Хорош коупить, погнали лучше в казиныч!\nЗаодно посмотрим насколько хорошо твой коуп сможет выбить нам 3 лимона", do_quote=False)
         sleep(0.5)
-        await update.message.reply_dice(emoji="🎰", quote=False)
+        await update.message.reply_dice(emoji="🎰", do_quote=False)
     elif res == 30:
-        await update.message.reply_text(f"Хорош коупить, погнали лучше в боулинг!\nЗаодно посмотрим насколько хорошо твой коуп умеет выбивать кегли", quote=False)
+        await update.message.reply_text(f"Хорош коупить, погнали лучше в боулинг!\nЗаодно посмотрим насколько хорошо твой коуп умеет выбивать кегли", do_quote=False)
         sleep(0.5)
-        await update.message.reply_dice(emoji="🎳", quote=False)
+        await update.message.reply_dice(emoji="🎳", do_quote=False)
     elif res == 31:
-        await update.message.reply_text(f"Хорош коупить, погнали лучше в дартс!\nЗаодно посмотрим насколько хорошо твой коуп попадает в яблочко!", quote=False)
+        await update.message.reply_text(f"Хорош коупить, погнали лучше в дартс!\nЗаодно посмотрим насколько хорошо твой коуп попадает в яблочко!", do_quote=False)
         sleep(0.5)
-        await update.message.reply_dice(emoji="🎯", quote=False)
+        await update.message.reply_dice(emoji="🎯", do_quote=False)
     elif res == 32:
-        await update.message.reply_text(f"Хорош коупить, погнали лучше в футбол!\nЗаодно посмотрим насколько хорошо твой коуп залетает в ворота", quote=False)
+        await update.message.reply_text(f"Хорош коупить, погнали лучше в футбол!\nЗаодно посмотрим насколько хорошо твой коуп залетает в ворота", do_quote=False)
         sleep(0.5)
-        await update.message.reply_dice(emoji="⚽", quote=False)
+        await update.message.reply_dice(emoji="⚽", do_quote=False)
     elif res == 33:
-        await update.message.reply_text(f"Хорош коупить, погнали лучше в баскетбол!\nЗаодно посмотрим насколько хорошо твой коуп залетает в корзину", quote=False)
+        await update.message.reply_text(f"Хорош коупить, погнали лучше в баскетбол!\nЗаодно посмотрим насколько хорошо твой коуп залетает в корзину", do_quote=False)
         sleep(0.5)
-        await update.message.reply_dice(emoji="🏀", quote=False)
+        await update.message.reply_dice(emoji="🏀", do_quote=False)
 
 
 

--- a/random_cope.py
+++ b/random_cope.py
@@ -11,7 +11,7 @@ from opinion import opinion
 logger = logging.getLogger(__name__)
 r = redis_db.connect()
 
-def random_cope(update: Update, context):
+async def random_cope(update: Update, context: CallbackContext):
     if (not in_whitelist(update)):
         return
     options = [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33]
@@ -19,115 +19,115 @@ def random_cope(update: Update, context):
     res = random.choices(options, weights=weights)[0]
     logger.info(f"[cope] res {res}")
     if res == 1:
-        update.message.reply_text(f"Найс коупишь", quote=False)
+        await update.message.reply_text(f"Найс коупишь", quote=False)
     elif res == 2:
-        update.message.reply_text(f"Коуп жиденький", quote=False)
+        await update.message.reply_text(f"Коуп жиденький", quote=False)
     elif res == 3:
-        update.message.reply_text(f"Коуп хороший\nЗдорово покоупил", quote=False)
+        await update.message.reply_text(f"Коуп хороший\nЗдорово покоупил", quote=False)
     elif res == 4:
-        update.message.reply_text(f"Коуп плохой\nКоупи лучше", quote=False)
+        await update.message.reply_text(f"Коуп плохой\nКоупи лучше", quote=False)
     elif res == 5:
-        update.message.reply_text(f"Коуп отвратительный", quote=False)
+        await update.message.reply_text(f"Коуп отвратительный", quote=False)
     elif res == 6:
-        update.message.reply_text(f"=== ЛЕГЕНДАРНЫЙ КОУП ===\nЭтот коуп войдет в историю!\nПоздравляем @{update.message.from_user.username} с получением этого невероятного редкого коупа", quote=False)
+        await update.message.reply_text(f"=== ЛЕГЕНДАРНЫЙ КОУП ===\nЭтот коуп войдет в историю!\nПоздравляем @{update.message.from_user.username} с получением этого невероятного редкого коупа", quote=False)
     elif res == 7:
-        update.message.reply_text(f"Коуп слабый\nКоупи сильнее", quote=False)
+        await update.message.reply_text(f"Коуп слабый\nКоупи сильнее", quote=False)
     elif res == 8:
-        update.message.reply_text(f"Тариф Гигакоупище\nБезлимитный коуп по всей России", quote=False)
+        await update.message.reply_text(f"Тариф Гигакоупище\nБезлимитный коуп по всей России", quote=False)
     elif res == 9:
-        update.message.reply_text(f"Лютейший коуп", quote=False)
+        await update.message.reply_text(f"Лютейший коуп", quote=False)
     elif res == 10:
-        update.message.reply_text(f"Удачный коуп!\nМожешь еще раз покоупить", quote=False)
+        await update.message.reply_text(f"Удачный коуп!\nМожешь еще раз покоупить", quote=False)
     elif res == 11:
-        update.message.reply_text(f"Этот божественный коуп настолько силен, что способен излучать ауру добра и позитива, которая увеличивает силу коупа друзей на 50%", quote=False)
+        await update.message.reply_text(f"Этот божественный коуп настолько силен, что способен излучать ауру добра и позитива, которая увеличивает силу коупа друзей на 50%", quote=False)
     elif res == 12:
-        update.message.reply_text(f"Выбираем главного коупера дня", quote=False)
+        await update.message.reply_text(f"Выбираем главного коупера дня", quote=False)
         sleep(1.5)
-        update.message.reply_text(random.choice(["Хмм...", "Так-так-так...", "Расшифровываю результаты...", "Спрашиваем мнения экспертов...", "Дайте подумать..."]), quote=False)
+        await update.message.reply_text(random.choice(["Хмм...", "Так-так-так...", "Расшифровываю результаты...", "Спрашиваем мнения экспертов...", "Дайте подумать..."]), quote=False)
         sleep(1.5)
-        update.message.reply_text(f"А вот и победитель - @{update.message.from_user.username}!", quote=False)
+        await update.message.reply_text(f"А вот и победитель - @{update.message.from_user.username}!", quote=False)
     elif res == 13:
-        update.message.reply_text(f"Как же он сильно коупит...\nПарень полегче!", quote=False)
+        await update.message.reply_text(f"Как же он сильно коупит...\nПарень полегче!", quote=False)
     elif res == 14:
-        update.message.reply_text(f"Критически плохой коуп!\nУ тебя весь день будет ФОМО", quote=False)
+        await update.message.reply_text(f"Критически плохой коуп!\nУ тебя весь день будет ФОМО", quote=False)
     elif res == 15:
-        update.message.reply_text(f"Отличный коуп!\nВсе проблемы решены", quote=False)
+        await update.message.reply_text(f"Отличный коуп!\nВсе проблемы решены", quote=False)
     elif res == 16:
-        update.message.reply_text(f"Шедевральный коуп!\nО нем напишут в книгах", quote=False)
+        await update.message.reply_text(f"Шедевральный коуп!\nО нем напишут в книгах", quote=False)
     elif res == 17:
-        update.message.reply_text(f"Я не вижу вашего коупа", quote=False)
+        await update.message.reply_text(f"Я не вижу вашего коупа", quote=False)
     elif res == 18:
         values = list(r.hgetall(DICTIONARY_HASH).values())
         values = [val for val in values if val.startswith(STICKER_PREFIX)]
         if len(values) == 0:
-            update.message.reply_animation("CgACAgQAAx0CT_IhJQABBXMmY7qlHgn9TsIE04UL3TKhfZGCmOgAAmIDAAJ43PVSPgZ0f8U9qU4tBA", quote=False)
+            await update.message.reply_animation("CgACAgQAAx0CT_IhJQABBXMmY7qlHgn9TsIE04UL3TKhfZGCmOgAAmIDAAJ43PVSPgZ0f8U9qU4tBA", quote=False)
             return
         random.shuffle(values)
         file_id = values[0][len(STICKER_PREFIX):]
         logger.info(f"fileid {file_id}")
-        update.message.reply_sticker(file_id, quote=False)
+        await update.message.reply_sticker(file_id, quote=False)
     elif res == 19:
         values = list(r.hgetall(DICTIONARY_HASH).values())
         values = [val for val in values if val.startswith(GIF_PREFIX)]
         if len(values) == 0:
-            update.message.reply_animation("CgACAgQAAx0CT_IhJQABBXMmY7qlHgn9TsIE04UL3TKhfZGCmOgAAmIDAAJ43PVSPgZ0f8U9qU4tBA", quote=False)
+            await update.message.reply_animation("CgACAgQAAx0CT_IhJQABBXMmY7qlHgn9TsIE04UL3TKhfZGCmOgAAmIDAAJ43PVSPgZ0f8U9qU4tBA", quote=False)
             return
         random.shuffle(values)
         file_id = values[0][len(GIF_PREFIX):]
         logger.info(f"fileid {file_id}")
-        update.message.reply_animation(file_id, quote=False)
+        await update.message.reply_animation(file_id, quote=False)
     elif res == 20:
-        update.message.reply_text(f"Кто-то сомневается в твоем коупе? Вызови его на дуэль в /rockpaperscissors и посмотри чей коуп победит!", quote=False)
+        await update.message.reply_text(f"Кто-то сомневается в твоем коупе? Вызови его на дуэль в /rockpaperscissors и посмотри чей коуп победит!", quote=False)
     elif res == 21:
-        update.message.reply_text(f"Кто-то сомневается в твоем коупе? Вызови его на дуэль в /connectfour и посмотри чей коуп победит!", quote=False)
+        await update.message.reply_text(f"Кто-то сомневается в твоем коупе? Вызови его на дуэль в /connectfour и посмотри чей коуп победит!", quote=False)
     elif res == 22:
         keys = list(r.hgetall(DICTIONARY_HASH).keys())
         keys = [key for key in keys if key.lower().startswith("коуп")]
         if len(keys) == 0:
-            update.message.reply_animation("CgACAgQAAx0CT_IhJQABBXMmY7qlHgn9TsIE04UL3TKhfZGCmOgAAmIDAAJ43PVSPgZ0f8U9qU4tBA", quote=False)
+            await update.message.reply_animation("CgACAgQAAx0CT_IhJQABBXMmY7qlHgn9TsIE04UL3TKhfZGCmOgAAmIDAAJ43PVSPgZ0f8U9qU4tBA", quote=False)
             return
         random.shuffle(keys)
         key = keys[0]
-        update.message.reply_text(f"/get {key}", quote=False)
+        await update.message.reply_text(f"/get {key}", quote=False)
         sleep(0.5)
         logger.info(f"cope get {key}")
         update.message.text = f"/get {key}"
         getDict(update, context)
     elif res == 23:
-        opinion(update, context, "коуп")
+        await opinion(update, context, "коуп")
     elif res == 24:
-        update.message.reply_text(f"Оцениваем силу коупа от 1 до 6", quote=False)
+        await update.message.reply_text(f"Оцениваем силу коупа от 1 до 6", quote=False)
         sleep(0.5)
-        update.message.reply_dice(quote=False)
+        await update.message.reply_dice(quote=False)
     elif res == 25:
         # Cope harder sir
-        update.message.reply_animation("CgACAgQAAx0CT_IhJQABBXMmY7qlHgn9TsIE04UL3TKhfZGCmOgAAmIDAAJ43PVSPgZ0f8U9qU4tBA", quote=False)
+        await update.message.reply_animation("CgACAgQAAx0CT_IhJQABBXMmY7qlHgn9TsIE04UL3TKhfZGCmOgAAmIDAAJ43PVSPgZ0f8U9qU4tBA", quote=False)
     elif res == 26:
-        update.message.reply_text(f"Врать не буду, коуп не впечатлил", quote=False)
+        await update.message.reply_text(f"Врать не буду, коуп не впечатлил", quote=False)
     elif res == 27:
-        update.message.reply_text(f"Удовлетворительный коуп", quote=False)
+        await update.message.reply_text(f"Удовлетворительный коуп", quote=False)
     elif res == 28:
-        update.message.reply_text(f"Взорванный коуп!", quote=False)
+        await update.message.reply_text(f"Взорванный коуп!", quote=False)
     elif res == 29:
-        update.message.reply_text(f"Хорош коупить, погнали лучше в казиныч!\nЗаодно посмотрим насколько хорошо твой коуп сможет выбить нам 3 лимона", quote=False)
+        await update.message.reply_text(f"Хорош коупить, погнали лучше в казиныч!\nЗаодно посмотрим насколько хорошо твой коуп сможет выбить нам 3 лимона", quote=False)
         sleep(0.5)
-        update.message.reply_dice(emoji="🎰", quote=False)
+        await update.message.reply_dice(emoji="🎰", quote=False)
     elif res == 30:
-        update.message.reply_text(f"Хорош коупить, погнали лучше в боулинг!\nЗаодно посмотрим насколько хорошо твой коуп умеет выбивать кегли", quote=False)
+        await update.message.reply_text(f"Хорош коупить, погнали лучше в боулинг!\nЗаодно посмотрим насколько хорошо твой коуп умеет выбивать кегли", quote=False)
         sleep(0.5)
-        update.message.reply_dice(emoji="🎳", quote=False)
+        await update.message.reply_dice(emoji="🎳", quote=False)
     elif res == 31:
-        update.message.reply_text(f"Хорош коупить, погнали лучше в дартс!\nЗаодно посмотрим насколько хорошо твой коуп попадает в яблочко!", quote=False)
+        await update.message.reply_text(f"Хорош коупить, погнали лучше в дартс!\nЗаодно посмотрим насколько хорошо твой коуп попадает в яблочко!", quote=False)
         sleep(0.5)
-        update.message.reply_dice(emoji="🎯", quote=False)
+        await update.message.reply_dice(emoji="🎯", quote=False)
     elif res == 32:
-        update.message.reply_text(f"Хорош коупить, погнали лучше в футбол!\nЗаодно посмотрим насколько хорошо твой коуп залетает в ворота", quote=False)
+        await update.message.reply_text(f"Хорош коупить, погнали лучше в футбол!\nЗаодно посмотрим насколько хорошо твой коуп залетает в ворота", quote=False)
         sleep(0.5)
-        update.message.reply_dice(emoji="⚽", quote=False)
+        await update.message.reply_dice(emoji="⚽", quote=False)
     elif res == 33:
-        update.message.reply_text(f"Хорош коупить, погнали лучше в баскетбол!\nЗаодно посмотрим насколько хорошо твой коуп залетает в корзину", quote=False)
+        await update.message.reply_text(f"Хорош коупить, погнали лучше в баскетбол!\nЗаодно посмотрим насколько хорошо твой коуп залетает в корзину", quote=False)
         sleep(0.5)
-        update.message.reply_dice(emoji="🏀", quote=False)
+        await update.message.reply_dice(emoji="🏀", quote=False)
 
 
 

--- a/random_cope.py
+++ b/random_cope.py
@@ -3,7 +3,6 @@ from telegram.ext import Application, CallbackContext, CommandHandler
 import random
 import asyncio
 import redis_db
-from utils import in_whitelist
 import logging
 from main import send_get_value, DICTIONARY_HASH, GIF_PREFIX, STICKER_PREFIX
 from opinion import opinion
@@ -12,8 +11,6 @@ logger = logging.getLogger(__name__)
 r = redis_db.connect()
 
 async def random_cope(update: Update, context: CallbackContext):
-    if (not in_whitelist(update)):
-        return
     options = [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33]
     weights = [100, 100, 100, 100, 60, 0.1, 100, 4, 50, 15, 3, 3, 40, 15, 20, 1, 6, 6, 6, 1.5, 1.5, 35, 20, 90, 50, 90, 100, 12, 1, 0.5, 0.5, 0.5, 0.5]
     res = random.choices(options, weights=weights)[0]

--- a/random_cope.py
+++ b/random_cope.py
@@ -1,11 +1,11 @@
-from telegram import ParseMode, Update
-from telegram.ext import Updater, CommandHandler
+from telegram import Update
+from telegram.ext import Application, CallbackContext, CommandHandler
 import random
+import asyncio
 import redis_db
 from utils import in_whitelist
 import logging
-from time import sleep
-from main import getDict, DICTIONARY_HASH, GIF_PREFIX, STICKER_PREFIX
+from main import send_get_value, DICTIONARY_HASH, GIF_PREFIX, STICKER_PREFIX
 from opinion import opinion
 
 logger = logging.getLogger(__name__)
@@ -42,9 +42,9 @@ async def random_cope(update: Update, context: CallbackContext):
         await update.message.reply_text(f"Этот божественный коуп настолько силен, что способен излучать ауру добра и позитива, которая увеличивает силу коупа друзей на 50%", do_quote=False)
     elif res == 12:
         await update.message.reply_text(f"Выбираем главного коупера дня", do_quote=False)
-        sleep(1.5)
+        await asyncio.sleep(1.5)
         await update.message.reply_text(random.choice(["Хмм...", "Так-так-так...", "Расшифровываю результаты...", "Спрашиваем мнения экспертов...", "Дайте подумать..."]), do_quote=False)
-        sleep(1.5)
+        await asyncio.sleep(1.5)
         await update.message.reply_text(f"А вот и победитель - @{update.message.from_user.username}!", do_quote=False)
     elif res == 13:
         await update.message.reply_text(f"Как же он сильно коупит...\nПарень полегче!", do_quote=False)
@@ -89,15 +89,15 @@ async def random_cope(update: Update, context: CallbackContext):
         random.shuffle(keys)
         key = keys[0]
         await update.message.reply_text(f"/get {key}", do_quote=False)
-        sleep(0.5)
+        await asyncio.sleep(0.5)
         logger.info(f"cope get {key}")
-        update.message.text = f"/get {key}"
-        getDict(update, context)
+        value = r.hget(DICTIONARY_HASH, key)
+        await send_get_value(update, key, value, show_header=True)
     elif res == 23:
         await opinion(update, context, "коуп")
     elif res == 24:
         await update.message.reply_text(f"Оцениваем силу коупа от 1 до 6", do_quote=False)
-        sleep(0.5)
+        await asyncio.sleep(0.5)
         await update.message.reply_dice(do_quote=False)
     elif res == 25:
         # Cope harder sir
@@ -110,27 +110,27 @@ async def random_cope(update: Update, context: CallbackContext):
         await update.message.reply_text(f"Взорванный коуп!", do_quote=False)
     elif res == 29:
         await update.message.reply_text(f"Хорош коупить, погнали лучше в казиныч!\nЗаодно посмотрим насколько хорошо твой коуп сможет выбить нам 3 лимона", do_quote=False)
-        sleep(0.5)
+        await asyncio.sleep(0.5)
         await update.message.reply_dice(emoji="🎰", do_quote=False)
     elif res == 30:
         await update.message.reply_text(f"Хорош коупить, погнали лучше в боулинг!\nЗаодно посмотрим насколько хорошо твой коуп умеет выбивать кегли", do_quote=False)
-        sleep(0.5)
+        await asyncio.sleep(0.5)
         await update.message.reply_dice(emoji="🎳", do_quote=False)
     elif res == 31:
         await update.message.reply_text(f"Хорош коупить, погнали лучше в дартс!\nЗаодно посмотрим насколько хорошо твой коуп попадает в яблочко!", do_quote=False)
-        sleep(0.5)
+        await asyncio.sleep(0.5)
         await update.message.reply_dice(emoji="🎯", do_quote=False)
     elif res == 32:
         await update.message.reply_text(f"Хорош коупить, погнали лучше в футбол!\nЗаодно посмотрим насколько хорошо твой коуп залетает в ворота", do_quote=False)
-        sleep(0.5)
+        await asyncio.sleep(0.5)
         await update.message.reply_dice(emoji="⚽", do_quote=False)
     elif res == 33:
         await update.message.reply_text(f"Хорош коупить, погнали лучше в баскетбол!\nЗаодно посмотрим насколько хорошо твой коуп залетает в корзину", do_quote=False)
-        sleep(0.5)
+        await asyncio.sleep(0.5)
         await update.message.reply_dice(emoji="🏀", do_quote=False)
 
 
 
-def subscribe(u: Updater):
-    u.dispatcher.add_handler(CommandHandler("cope", random_cope))
+def subscribe(a: Application):
+    a.add_handler(CommandHandler("cope", random_cope))
     pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-python-telegram-bot==13.1
+python-telegram-bot==22.6
 redis==4.4.0
 markovify==0.9.4

--- a/rps_game.py
+++ b/rps_game.py
@@ -3,7 +3,7 @@ from telegram.error import RetryAfter
 from telegram.ext import Application, CallbackContext, CommandHandler, CallbackQueryHandler
 import redis_db
 import re
-from utils import in_whitelist, parse_userid
+from utils import parse_userid
 import random
 import json
 
@@ -66,8 +66,6 @@ def get_rps_keyboard(pregame: bool = False) -> InlineKeyboardMarkup:
 
 
 async def start_rps(update: Update, context: CallbackContext):
-    if (not in_whitelist(update)):
-        return
     match = re.match(r'/[\S]+\s+(.+)', update.message.text)
     if (match == None):
         if update.message.reply_to_message is not None:

--- a/rps_game.py
+++ b/rps_game.py
@@ -65,7 +65,7 @@ def get_rps_keyboard(pregame: bool = False) -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(keyboard)
 
 
-def start_rps(update: Update, context: CallbackContext):
+async def start_rps(update: Update, context: CallbackContext):
     if (not in_whitelist(update)):
         return
     match = re.match(r'/[\S]+\s+(.+)', update.message.text)
@@ -75,7 +75,7 @@ def start_rps(update: Update, context: CallbackContext):
         else:
             username_1 = redis_db.get_username_by_id(update.message.from_user.id)
             new_game_state = {"message_id": "", "player_ids": [update.message.from_user.id, None], "player_usernames": [username_1, ""], "decisions": ["", ""], "current_round": 1, "scores": [0, 0], "log": "", "over": False}
-            message = update.message.reply_text(f"{format_playing_field(new_game_state)}", reply_markup=get_rps_keyboard(True), quote=False)
+            message = await update.message.reply_text(f"{format_playing_field(new_game_state)}", reply_markup=get_rps_keyboard(True), quote=False)
             new_game_state["message_id"] = str(message.chat_id) + "/" + str(message.message_id)
             games_data.append(new_game_state)
             clean_old_games()
@@ -84,18 +84,18 @@ def start_rps(update: Update, context: CallbackContext):
         user_id = parse_userid(match.group(1), context)
 
     if user_id is None:
-        update.message.reply_text(
+        await update.message.reply_text(
             f"Кто такой \"{match.group(1)}\"? Что-то я таких не знаю...", quote=False)
         return
     elif str(user_id) == str(update.message.from_user.id):
-        update.message.reply_text("Одиноко? Можешь поиграть со мной!", quote=True)
+        await update.message.reply_text("Одиноко? Можешь поиграть со мной!", quote=True)
         return
     
     username_1 = redis_db.get_username_by_id(update.message.from_user.id)
     # Hack... should be included in the get username function maybe?
     username_2 = context.bot.username if int(user_id) == context.bot.id else redis_db.get_username_by_id(user_id)
     new_game_state = {"message_id": "", "player_ids": [update.message.from_user.id, int(user_id)], "player_usernames": [username_1, username_2], "decisions": ["", ""], "current_round": 1, "scores": [0, 0], "log": "", "over": False}
-    message = update.message.reply_text(f"{format_playing_field(new_game_state)}", reply_markup=get_rps_keyboard(False), quote=False)
+    message = await update.message.reply_text(f"{format_playing_field(new_game_state)}", reply_markup=get_rps_keyboard(False), quote=False)
     new_game_state["message_id"] = str(message.chat_id) + "/" + str(message.message_id)
     games_data.append(new_game_state)
     clean_old_games()
@@ -111,7 +111,7 @@ def get_decision_emoji(symbol: str) -> str:
     return "??"
 
 
-def on_rps_action(update: Update, context: CallbackContext):
+async def on_rps_action(update: Update, context: CallbackContext):
     query = update.callback_query
     # Not checking for whitelist because its broken with callback query...
     # But we still check if the message from query exists in our database so all is good!
@@ -124,7 +124,7 @@ def on_rps_action(update: Update, context: CallbackContext):
             break
             
     if game_state is None:
-        query.answer("Не могу найти данные этой игры :(")
+        await query.answer("Не могу найти данные этой игры :(")
         return
     
     if query.data == "rps_join":
@@ -132,10 +132,10 @@ def on_rps_action(update: Update, context: CallbackContext):
             game_state['player_ids'][1] = query.from_user.id
             game_state['player_usernames'][1] = redis_db.get_username_by_id(query.from_user.id)
             try:
-                query.edit_message_text(text=format_playing_field(game_state), reply_markup=get_rps_keyboard(False))
+                await query.edit_message_text(text=format_playing_field(game_state), reply_markup=get_rps_keyboard(False))
             except:
                 game_state['player_ids'][1] = None
-        query.answer()
+        await query.answer()
         return
 
     player_index = -1
@@ -145,7 +145,7 @@ def on_rps_action(update: Update, context: CallbackContext):
             break
 
     if player_index < 0 or game_state["over"]:
-        query.answer()
+        await query.answer()
         return
     
     prev_game_state = json.loads(json.dumps(game_state))
@@ -186,7 +186,7 @@ def on_rps_action(update: Update, context: CallbackContext):
             game_state["current_round"] += 1 
 
     if game_state["over"]:
-        edit_res = try_edit(query, game_state, None)
+        edit_res = await try_edit(query, game_state, None)
         if edit_res:
             games_data.remove(game_state)
         else:
@@ -194,25 +194,25 @@ def on_rps_action(update: Update, context: CallbackContext):
                 if state == game_state:
                     games_data[index] = prev_game_state
     else:
-        edit_res = try_edit(query, game_state, query.message.reply_markup)
+        edit_res = await try_edit(query, game_state, query.message.reply_markup)
         if not edit_res:
             for index, state in enumerate(games_data):
                 if state == game_state:
                     games_data[index] = prev_game_state
 
 
-def try_edit(query, game_state, reply_markup = None) -> bool:
+async def try_edit(query, game_state, reply_markup = None) -> bool:
     try:
-        query.edit_message_text(text=format_playing_field(game_state), reply_markup=reply_markup)
-        query.answer()
+        await query.edit_message_text(text=format_playing_field(game_state), reply_markup=reply_markup)
+        await query.answer()
         return True
     except RetryAfter:
-        query.answer("Не получилось обновить игру из-за защиты от спама :(")
+        await query.answer("Не получилось обновить игру из-за защиты от спама :(")
         return False
     except Exception as e:
         #print(traceback.format_exc())
         print(e)
-        query.answer()
+        await query.answer()
         return True
 
 

--- a/rps_game.py
+++ b/rps_game.py
@@ -75,7 +75,7 @@ async def start_rps(update: Update, context: CallbackContext):
         else:
             username_1 = redis_db.get_username_by_id(update.message.from_user.id)
             new_game_state = {"message_id": "", "player_ids": [update.message.from_user.id, None], "player_usernames": [username_1, ""], "decisions": ["", ""], "current_round": 1, "scores": [0, 0], "log": "", "over": False}
-            message = await update.message.reply_text(f"{format_playing_field(new_game_state)}", reply_markup=get_rps_keyboard(True), quote=False)
+            message = await update.message.reply_text(f"{format_playing_field(new_game_state)}", reply_markup=get_rps_keyboard(True), do_quote=False)
             new_game_state["message_id"] = str(message.chat_id) + "/" + str(message.message_id)
             games_data.append(new_game_state)
             clean_old_games()
@@ -85,17 +85,17 @@ async def start_rps(update: Update, context: CallbackContext):
 
     if user_id is None:
         await update.message.reply_text(
-            f"Кто такой \"{match.group(1)}\"? Что-то я таких не знаю...", quote=False)
+            f"Кто такой \"{match.group(1)}\"? Что-то я таких не знаю...", do_quote=False)
         return
     elif str(user_id) == str(update.message.from_user.id):
-        await update.message.reply_text("Одиноко? Можешь поиграть со мной!", quote=True)
+        await update.message.reply_text("Одиноко? Можешь поиграть со мной!", do_quote=True)
         return
     
     username_1 = redis_db.get_username_by_id(update.message.from_user.id)
     # Hack... should be included in the get username function maybe?
     username_2 = context.bot.username if int(user_id) == context.bot.id else redis_db.get_username_by_id(user_id)
     new_game_state = {"message_id": "", "player_ids": [update.message.from_user.id, int(user_id)], "player_usernames": [username_1, username_2], "decisions": ["", ""], "current_round": 1, "scores": [0, 0], "log": "", "over": False}
-    message = await update.message.reply_text(f"{format_playing_field(new_game_state)}", reply_markup=get_rps_keyboard(False), quote=False)
+    message = await update.message.reply_text(f"{format_playing_field(new_game_state)}", reply_markup=get_rps_keyboard(False), do_quote=False)
     new_game_state["message_id"] = str(message.chat_id) + "/" + str(message.message_id)
     games_data.append(new_game_state)
     clean_old_games()

--- a/rps_game.py
+++ b/rps_game.py
@@ -1,6 +1,6 @@
-from telegram import ParseMode, Update, InlineKeyboardButton, InlineKeyboardMarkup
+from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.error import RetryAfter
-from telegram.ext import Updater, CommandHandler, CallbackQueryHandler, CallbackContext
+from telegram.ext import Application, CallbackContext, CommandHandler, CallbackQueryHandler
 import redis_db
 import re
 from utils import in_whitelist, parse_userid
@@ -216,6 +216,6 @@ async def try_edit(query, game_state, reply_markup = None) -> bool:
         return True
 
 
-def subscribe(u: Updater):
-    u.dispatcher.add_handler(CommandHandler(("rps", "rockpaperscissors"), start_rps))
-    u.dispatcher.add_handler(CallbackQueryHandler(on_rps_action, pattern="^rps_"))
+def subscribe(a: Application):
+    a.add_handler(CommandHandler(("rps", "rockpaperscissors"), start_rps))
+    a.add_handler(CallbackQueryHandler(on_rps_action, pattern="^rps_"))

--- a/slap_game.py
+++ b/slap_game.py
@@ -1,5 +1,6 @@
-from telegram import ParseMode, Update
-from telegram.ext import Updater, CommandHandler
+from telegram import Update
+from telegram.ext import Application, CallbackContext, CommandHandler
+from telegram.constants import ParseMode
 import redis_db
 import re
 from utils import in_whitelist, parse_userid
@@ -248,11 +249,11 @@ async def reset_my_slap(update: Update, context: CallbackContext):
     await update.message.reply_text("You can now /slap again. This is a debug command that should be removed on prod", do_quote=False)
 
 
-def subscribe(u: Updater):
-    u.dispatcher.add_handler(CommandHandler("slap", slap))
-    u.dispatcher.add_handler(CommandHandler("heal", heal))
-    u.dispatcher.add_handler(CommandHandler("parry", parry))
-    u.dispatcher.add_handler(CommandHandler("slapstats", slap_stats))
-    u.dispatcher.add_handler(CommandHandler("slaprules", slap_rules))
-    u.dispatcher.add_handler(CommandHandler("resetmyslap", reset_my_slap))
+def subscribe(a: Application):
+    a.add_handler(CommandHandler("slap", slap))
+    a.add_handler(CommandHandler("heal", heal))
+    a.add_handler(CommandHandler("parry", parry))
+    a.add_handler(CommandHandler("slapstats", slap_stats))
+    a.add_handler(CommandHandler("slaprules", slap_rules))
+    a.add_handler(CommandHandler("resetmyslap", reset_my_slap))
     pass

--- a/slap_game.py
+++ b/slap_game.py
@@ -3,7 +3,7 @@ from telegram.ext import Application, CallbackContext, CommandHandler
 from telegram.constants import ParseMode
 import redis_db
 import re
-from utils import in_whitelist, parse_userid
+from utils import parse_userid
 import random
 import json
 from datetime import datetime, timedelta, time
@@ -49,9 +49,6 @@ def is_cooldown_active(cooldown_start_date_str) -> bool:
 
 
 async def slap(update: Update, context: CallbackContext):
-    if (not in_whitelist(update)):
-        return
-
     stats = get_slap_stats(update.message.from_user.id)
     if is_cooldown_active(stats.get(SS_MADE_ACTION_DATE)):
         await update.message.reply_text(
@@ -101,8 +98,6 @@ async def slap(update: Update, context: CallbackContext):
 
 
 async def heal(update: Update, context: CallbackContext):
-    if (not in_whitelist(update)):
-        return
     stats = get_slap_stats(update.message.from_user.id)
     if is_cooldown_active(stats.get(SS_MADE_ACTION_DATE)):
         await update.message.reply_text(
@@ -153,9 +148,6 @@ async def heal(update: Update, context: CallbackContext):
         
 
 async def parry(update: Update, context: CallbackContext):
-    if (not in_whitelist(update)):
-        return
-
     stats = get_slap_stats(update.message.from_user.id)
     if is_cooldown_active(stats.get(SS_VULNERABLE_DATE)):
         await update.message.reply_text("Ты уязвим и не можешь парировать", do_quote=True)
@@ -200,8 +192,6 @@ async def parry(update: Update, context: CallbackContext):
 
 
 async def slap_stats(update: Update, context: CallbackContext):
-    if (not in_whitelist(update)):
-        return
     slappers_dict = {}
     for key in r.hgetall(SLAP_STATS_HASH):
         username = redis_db.get_username_by_id(key)
@@ -228,8 +218,6 @@ async def slap_stats(update: Update, context: CallbackContext):
 
 
 async def slap_rules(update: Update, context: CallbackContext):
-    if (not in_whitelist(update)):
-        return
     rules = "Правила /slap игры.\n" + \
             "Ты можешь шлепнуть любого игрока, отправив /slap и указав другого игрока (по его username или кастомному никнейму). Это снизит его шлеп-счет на 1.\n" + \
             "Когда игрока шлепнули, он может отправить /parry чтобы заблокировать шлепок. Если /parry был отправлен в течение минуты после последнего шлепка, эта атака будет успешно заблокирована и игрок не получит урона.\n" + \
@@ -241,8 +229,6 @@ async def slap_rules(update: Update, context: CallbackContext):
 
 
 async def reset_my_slap(update: Update, context: CallbackContext):
-    if (not in_whitelist(update)):
-        return
     stats = get_slap_stats(update.message.from_user.id)
     stats.pop(SS_MADE_ACTION_DATE, None)
     r.hset(SLAP_STATS_HASH, str(update.message.from_user.id), json.dumps(stats))

--- a/slap_game.py
+++ b/slap_game.py
@@ -54,7 +54,7 @@ async def slap(update: Update, context: CallbackContext):
     stats = get_slap_stats(update.message.from_user.id)
     if is_cooldown_active(stats.get(SS_MADE_ACTION_DATE)):
         await update.message.reply_text(
-            "Ты можешь делать только один /slap или /heal за день!", quote=True)
+            "Ты можешь делать только один /slap или /heal за день!", do_quote=True)
         return
 
     match = re.match(r'/[\S]+\s+(.+)', update.message.text)
@@ -62,7 +62,7 @@ async def slap(update: Update, context: CallbackContext):
         if update.message.reply_to_message is not None:
             user_id = update.message.reply_to_message.from_user.id
         else:
-            await update.message.reply_text("Кого будем шлепать?", quote=False)
+            await update.message.reply_text("Кого будем шлепать?", do_quote=False)
             return
     else:
         user_id = parse_userid(match.group(1), context)
@@ -74,14 +74,14 @@ async def slap(update: Update, context: CallbackContext):
 
     if not user_id:
         await update.message.reply_text(
-            f"Кто такой \"{match.group(1)}\"? Что-то я таких не знаю...", quote=False)
+            f"Кто такой \"{match.group(1)}\"? Что-то я таких не знаю...", do_quote=False)
         return
     elif str(user_id) == str(context.bot.id):
-        await update.message.reply_text("🤨", quote=True)
+        await update.message.reply_text("🤨", do_quote=True)
     elif (user_not_in_chat):
-        await update.message.reply_text("Ты хотел кого-то шлепнуть... но его не оказалось в чате", quote=True)
+        await update.message.reply_text("Ты хотел кого-то шлепнуть... но его не оказалось в чате", do_quote=True)
     elif str(user_id) == str(update.message.from_user.id):
-        await update.message.reply_text("Хочешь шлепнуть сам себя? Сделай это в реальной жизни", quote=True)
+        await update.message.reply_text("Хочешь шлепнуть сам себя? Сделай это в реальной жизни", do_quote=True)
     else:
         lucky_roll = random.random() < 0.05
         if not lucky_roll:
@@ -96,7 +96,7 @@ async def slap(update: Update, context: CallbackContext):
 
         append = f"\n\nУДАЧНЫЙ ШЛЕПОК!\n<b>{update.message.from_user.username}</b> может сделать еще одно действие сегодня!" if lucky_roll else ""
         await update.message.reply_text(
-            f"<b>{update.message.from_user.username}</b> шлепнул @{redis_db.get_username_by_id(user_id)} большой рыбой по лицу!{append}", quote=False, parse_mode=ParseMode.HTML)
+            f"<b>{update.message.from_user.username}</b> шлепнул @{redis_db.get_username_by_id(user_id)} большой рыбой по лицу!{append}", do_quote=False, parse_mode=ParseMode.HTML)
 
 
 async def heal(update: Update, context: CallbackContext):
@@ -105,7 +105,7 @@ async def heal(update: Update, context: CallbackContext):
     stats = get_slap_stats(update.message.from_user.id)
     if is_cooldown_active(stats.get(SS_MADE_ACTION_DATE)):
         await update.message.reply_text(
-            "Ты можешь делать только один /slap или /heal за день!", quote=True)
+            "Ты можешь делать только один /slap или /heal за день!", do_quote=True)
         return
 
     match = re.match(r'/[\S]+\s+(.+)', update.message.text)
@@ -113,7 +113,7 @@ async def heal(update: Update, context: CallbackContext):
         if update.message.reply_to_message is not None:
             user_id = update.message.reply_to_message.from_user.id
         else:
-            await update.message.reply_text("Кого будем лечить?", quote=False)
+            await update.message.reply_text("Кого будем лечить?", do_quote=False)
             return
     else:
         user_id = parse_userid(match.group(1), context)
@@ -125,14 +125,14 @@ async def heal(update: Update, context: CallbackContext):
 
     if not user_id:
         await update.message.reply_text(
-            f"Кто такой \"{match.group(1)}\"? Что-то я таких не знаю...", quote=False)
+            f"Кто такой \"{match.group(1)}\"? Что-то я таких не знаю...", do_quote=False)
         return
     elif str(user_id) == str(context.bot.id):
-        await update.message.reply_text("Спасибо, но я вне игры :^", quote=True)
+        await update.message.reply_text("Спасибо, но я вне игры :^", do_quote=True)
     elif (user_not_in_chat):
-        await update.message.reply_text("Ты хотел кого-то полечить... но его не оказалось в чате", quote=True)
+        await update.message.reply_text("Ты хотел кого-то полечить... но его не оказалось в чате", do_quote=True)
     elif str(user_id) == str(update.message.from_user.id):
-        await update.message.reply_text("Ты не можешь лечить сам себя!", quote=True)
+        await update.message.reply_text("Ты не можешь лечить сам себя!", do_quote=True)
     else:
         lucky_roll = random.random() < 0.05
         if not lucky_roll:
@@ -143,9 +143,9 @@ async def heal(update: Update, context: CallbackContext):
         append = f"\n\nУДАЧНОЕ ЛЕЧЕНИЕ!\n<b>{update.message.from_user.username}</b> может сделать еще одно действие сегодня!" if lucky_roll else ""
         if is_cooldown_active(other_user_stats.get(SS_VULNERABLE_DATE)):
             other_user_stats.pop(SS_VULNERABLE_DATE, None)
-            await update.message.reply_text(f"<b>{update.message.from_user.username}</b> погладил @{redis_db.get_username_by_id(user_id)} по голове и снял уязвимость!{append}", quote=False, parse_mode=ParseMode.HTML)
+            await update.message.reply_text(f"<b>{update.message.from_user.username}</b> погладил @{redis_db.get_username_by_id(user_id)} по голове и снял уязвимость!{append}", do_quote=False, parse_mode=ParseMode.HTML)
         else:
-            await update.message.reply_text(f"<b>{update.message.from_user.username}</b> погладил @{redis_db.get_username_by_id(user_id)} по голове.{append}", quote=False, parse_mode=ParseMode.HTML)
+            await update.message.reply_text(f"<b>{update.message.from_user.username}</b> погладил @{redis_db.get_username_by_id(user_id)} по голове.{append}", do_quote=False, parse_mode=ParseMode.HTML)
 
         r.hset(SLAP_STATS_HASH, str(update.message.from_user.id), json.dumps(stats))
         r.hset(SLAP_STATS_HASH, str(user_id), json.dumps(other_user_stats))
@@ -157,12 +157,12 @@ async def parry(update: Update, context: CallbackContext):
 
     stats = get_slap_stats(update.message.from_user.id)
     if is_cooldown_active(stats.get(SS_VULNERABLE_DATE)):
-        await update.message.reply_text("Ты уязвим и не можешь парировать", quote=True)
+        await update.message.reply_text("Ты уязвим и не можешь парировать", do_quote=True)
         return
 
     last_slapped_date_str = stats.get(SS_LAST_SLAPPED_DATE)
     if last_slapped_date_str is None:
-        await update.message.reply_text("Некого парировать", quote=True)
+        await update.message.reply_text("Некого парировать", do_quote=True)
         return
     
     last_slapped_date = datetime.strptime(last_slapped_date_str, DATETIME_FORMAT)
@@ -175,7 +175,7 @@ async def parry(update: Update, context: CallbackContext):
         other_user_stats[SS_HEALTH] = other_user_stats.get(SS_HEALTH, DEFAULT_HEALTH) - 1
         other_user_stats[SS_TOTAL_SLAPS] = other_user_stats.get(SS_TOTAL_SLAPS, 0) - 1
         other_user_stats[SS_VULNERABLE_DATE] = datetime.now().strftime(DATETIME_FORMAT)
-        await update.message.reply_text(f"ИДЕАЛЬНОЕ ПАРИРОВАНИЕ! <b>{update.message.from_user.username}</b> спарировал шлепок от @{redis_db.get_username_by_id(other_user_id)} и сделал его уязвимым на день!", quote=False, parse_mode=ParseMode.HTML)
+        await update.message.reply_text(f"ИДЕАЛЬНОЕ ПАРИРОВАНИЕ! <b>{update.message.from_user.username}</b> спарировал шлепок от @{redis_db.get_username_by_id(other_user_id)} и сделал его уязвимым на день!", do_quote=False, parse_mode=ParseMode.HTML)
         stats.pop(SS_LAST_SLAPPED_DATE, None)
         stats.pop(SS_LAST_SLAPPED_BY_USERID, None)
         r.hset(SLAP_STATS_HASH, str(update.message.from_user.id), json.dumps(stats))
@@ -186,13 +186,13 @@ async def parry(update: Update, context: CallbackContext):
         other_user_id = stats.get(SS_LAST_SLAPPED_BY_USERID, -1)
         other_user_stats = get_slap_stats(other_user_id)
         other_user_stats[SS_TOTAL_SLAPS] = other_user_stats.get(SS_TOTAL_SLAPS, 0) - 1
-        await update.message.reply_text(f"<b>{update.message.from_user.username}</b> спарировал шлепок от @{redis_db.get_username_by_id(other_user_id)}!", quote=False, parse_mode=ParseMode.HTML)
+        await update.message.reply_text(f"<b>{update.message.from_user.username}</b> спарировал шлепок от @{redis_db.get_username_by_id(other_user_id)}!", do_quote=False, parse_mode=ParseMode.HTML)
         stats.pop(SS_LAST_SLAPPED_DATE, None)
         stats.pop(SS_LAST_SLAPPED_BY_USERID, None)
         r.hset(SLAP_STATS_HASH, str(update.message.from_user.id), json.dumps(stats))
         r.hset(SLAP_STATS_HASH, str(other_user_id), json.dumps(other_user_stats))
     else:
-        await update.message.reply_text("Парирование провалено", quote=True)
+        await update.message.reply_text("Парирование провалено", do_quote=True)
         stats.pop(SS_LAST_SLAPPED_DATE, None)
         stats.pop(SS_LAST_SLAPPED_BY_USERID, None)
         r.hset(SLAP_STATS_HASH, str(update.message.from_user.id), json.dumps(stats))
@@ -207,7 +207,7 @@ async def slap_stats(update: Update, context: CallbackContext):
         slappers_dict[username] = get_slap_stats(key)
                 
     if len(slappers_dict.keys()) == 0:
-        await update.message.reply_text("Пока что никто никого не шлепал, поэтому и статистики нет", quote=False)
+        await update.message.reply_text("Пока что никто никого не шлепал, поэтому и статистики нет", do_quote=False)
         return
     message = f"Вот статистика шлепунов.\nИгрок [Шлеп-счет]  (Успешные шлепки / Лечения / Парирования / Идеальные парирования)\n\n"
     i = 1
@@ -223,7 +223,7 @@ async def slap_stats(update: Update, context: CallbackContext):
     time_to_next = datetime.combine(tomorrow, time.min) - datetime.now()
     time_to_next_h, time_to_next_m = time_to_next.seconds // 3600, (time_to_next.seconds // 60) % 60
     message += f"Новые шлепки будут доступны через {time_to_next_h} ч. и {time_to_next_m} м."
-    await update.message.reply_text(f"{message}", quote=False, parse_mode=ParseMode.HTML)
+    await update.message.reply_text(f"{message}", do_quote=False, parse_mode=ParseMode.HTML)
 
 
 async def slap_rules(update: Update, context: CallbackContext):
@@ -236,7 +236,7 @@ async def slap_rules(update: Update, context: CallbackContext):
             "Вместо шлепка ты можешь полечить кого-нибудь, отправив /heal и указав другого игрока. Это увеличит его шлеп-счет на 1, а также снимет уязвимость.\n" + \
             "За день ты можешь делать только один шлепок или лечение, но сколько угодно парирований.\n" + \
             "Отправь /slapstats, чтобы посмотреть общую статистику по игре."
-    await update.message.reply_text(rules, quote=False)
+    await update.message.reply_text(rules, do_quote=False)
 
 
 async def reset_my_slap(update: Update, context: CallbackContext):
@@ -245,7 +245,7 @@ async def reset_my_slap(update: Update, context: CallbackContext):
     stats = get_slap_stats(update.message.from_user.id)
     stats.pop(SS_MADE_ACTION_DATE, None)
     r.hset(SLAP_STATS_HASH, str(update.message.from_user.id), json.dumps(stats))
-    await update.message.reply_text("You can now /slap again. This is a debug command that should be removed on prod", quote=False)
+    await update.message.reply_text("You can now /slap again. This is a debug command that should be removed on prod", do_quote=False)
 
 
 def subscribe(u: Updater):

--- a/slap_game.py
+++ b/slap_game.py
@@ -47,13 +47,13 @@ def is_cooldown_active(cooldown_start_date_str) -> bool:
     return is_same_day
 
 
-def slap(update: Update, context):
+async def slap(update: Update, context: CallbackContext):
     if (not in_whitelist(update)):
         return
 
     stats = get_slap_stats(update.message.from_user.id)
     if is_cooldown_active(stats.get(SS_MADE_ACTION_DATE)):
-        update.message.reply_text(
+        await update.message.reply_text(
             "Ты можешь делать только один /slap или /heal за день!", quote=True)
         return
 
@@ -62,26 +62,26 @@ def slap(update: Update, context):
         if update.message.reply_to_message is not None:
             user_id = update.message.reply_to_message.from_user.id
         else:
-            update.message.reply_text("Кого будем шлепать?", quote=False)
+            await update.message.reply_text("Кого будем шлепать?", quote=False)
             return
     else:
         user_id = parse_userid(match.group(1), context)
     user_not_in_chat = False
     try:
-        user_not_in_chat = user_id is not None and context.bot.get_chat_member(update.message.chat_id, user_id).status == 'left'
+        user_not_in_chat = user_id is not None and (await context.bot.get_chat_member(update.message.chat_id, user_id)).status == 'left'
     except:
         user_not_in_chat = True
 
     if not user_id:
-        update.message.reply_text(
+        await update.message.reply_text(
             f"Кто такой \"{match.group(1)}\"? Что-то я таких не знаю...", quote=False)
         return
     elif str(user_id) == str(context.bot.id):
-        update.message.reply_text("🤨", quote=True)
+        await update.message.reply_text("🤨", quote=True)
     elif (user_not_in_chat):
-        update.message.reply_text("Ты хотел кого-то шлепнуть... но его не оказалось в чате", quote=True)
+        await update.message.reply_text("Ты хотел кого-то шлепнуть... но его не оказалось в чате", quote=True)
     elif str(user_id) == str(update.message.from_user.id):
-        update.message.reply_text("Хочешь шлепнуть сам себя? Сделай это в реальной жизни", quote=True)
+        await update.message.reply_text("Хочешь шлепнуть сам себя? Сделай это в реальной жизни", quote=True)
     else:
         lucky_roll = random.random() < 0.05
         if not lucky_roll:
@@ -95,16 +95,16 @@ def slap(update: Update, context):
         r.hset(SLAP_STATS_HASH, str(user_id), json.dumps(other_user_stats))
 
         append = f"\n\nУДАЧНЫЙ ШЛЕПОК!\n<b>{update.message.from_user.username}</b> может сделать еще одно действие сегодня!" if lucky_roll else ""
-        update.message.reply_text(
+        await update.message.reply_text(
             f"<b>{update.message.from_user.username}</b> шлепнул @{redis_db.get_username_by_id(user_id)} большой рыбой по лицу!{append}", quote=False, parse_mode=ParseMode.HTML)
 
 
-def heal(update: Update, context):
+async def heal(update: Update, context: CallbackContext):
     if (not in_whitelist(update)):
         return
     stats = get_slap_stats(update.message.from_user.id)
     if is_cooldown_active(stats.get(SS_MADE_ACTION_DATE)):
-        update.message.reply_text(
+        await update.message.reply_text(
             "Ты можешь делать только один /slap или /heal за день!", quote=True)
         return
 
@@ -113,26 +113,26 @@ def heal(update: Update, context):
         if update.message.reply_to_message is not None:
             user_id = update.message.reply_to_message.from_user.id
         else:
-            update.message.reply_text("Кого будем лечить?", quote=False)
+            await update.message.reply_text("Кого будем лечить?", quote=False)
             return
     else:
         user_id = parse_userid(match.group(1), context)
     user_not_in_chat = False
     try:
-        user_not_in_chat = user_id is not None and context.bot.get_chat_member(update.message.chat_id, user_id).status == 'left'
+        user_not_in_chat = user_id is not None and (await context.bot.get_chat_member(update.message.chat_id, user_id)).status == 'left'
     except:
         user_not_in_chat = True
 
     if not user_id:
-        update.message.reply_text(
+        await update.message.reply_text(
             f"Кто такой \"{match.group(1)}\"? Что-то я таких не знаю...", quote=False)
         return
     elif str(user_id) == str(context.bot.id):
-        update.message.reply_text("Спасибо, но я вне игры :^", quote=True)
+        await update.message.reply_text("Спасибо, но я вне игры :^", quote=True)
     elif (user_not_in_chat):
-        update.message.reply_text("Ты хотел кого-то полечить... но его не оказалось в чате", quote=True)
+        await update.message.reply_text("Ты хотел кого-то полечить... но его не оказалось в чате", quote=True)
     elif str(user_id) == str(update.message.from_user.id):
-        update.message.reply_text("Ты не можешь лечить сам себя!", quote=True)
+        await update.message.reply_text("Ты не можешь лечить сам себя!", quote=True)
     else:
         lucky_roll = random.random() < 0.05
         if not lucky_roll:
@@ -143,26 +143,26 @@ def heal(update: Update, context):
         append = f"\n\nУДАЧНОЕ ЛЕЧЕНИЕ!\n<b>{update.message.from_user.username}</b> может сделать еще одно действие сегодня!" if lucky_roll else ""
         if is_cooldown_active(other_user_stats.get(SS_VULNERABLE_DATE)):
             other_user_stats.pop(SS_VULNERABLE_DATE, None)
-            update.message.reply_text(f"<b>{update.message.from_user.username}</b> погладил @{redis_db.get_username_by_id(user_id)} по голове и снял уязвимость!{append}", quote=False, parse_mode=ParseMode.HTML)
+            await update.message.reply_text(f"<b>{update.message.from_user.username}</b> погладил @{redis_db.get_username_by_id(user_id)} по голове и снял уязвимость!{append}", quote=False, parse_mode=ParseMode.HTML)
         else:
-            update.message.reply_text(f"<b>{update.message.from_user.username}</b> погладил @{redis_db.get_username_by_id(user_id)} по голове.{append}", quote=False, parse_mode=ParseMode.HTML)
+            await update.message.reply_text(f"<b>{update.message.from_user.username}</b> погладил @{redis_db.get_username_by_id(user_id)} по голове.{append}", quote=False, parse_mode=ParseMode.HTML)
 
         r.hset(SLAP_STATS_HASH, str(update.message.from_user.id), json.dumps(stats))
         r.hset(SLAP_STATS_HASH, str(user_id), json.dumps(other_user_stats))
         
 
-def parry(update: Update, context):
+async def parry(update: Update, context: CallbackContext):
     if (not in_whitelist(update)):
         return
 
     stats = get_slap_stats(update.message.from_user.id)
     if is_cooldown_active(stats.get(SS_VULNERABLE_DATE)):
-        update.message.reply_text("Ты уязвим и не можешь парировать", quote=True)
+        await update.message.reply_text("Ты уязвим и не можешь парировать", quote=True)
         return
 
     last_slapped_date_str = stats.get(SS_LAST_SLAPPED_DATE)
     if last_slapped_date_str is None:
-        update.message.reply_text("Некого парировать", quote=True)
+        await update.message.reply_text("Некого парировать", quote=True)
         return
     
     last_slapped_date = datetime.strptime(last_slapped_date_str, DATETIME_FORMAT)
@@ -175,7 +175,7 @@ def parry(update: Update, context):
         other_user_stats[SS_HEALTH] = other_user_stats.get(SS_HEALTH, DEFAULT_HEALTH) - 1
         other_user_stats[SS_TOTAL_SLAPS] = other_user_stats.get(SS_TOTAL_SLAPS, 0) - 1
         other_user_stats[SS_VULNERABLE_DATE] = datetime.now().strftime(DATETIME_FORMAT)
-        update.message.reply_text(f"ИДЕАЛЬНОЕ ПАРИРОВАНИЕ! <b>{update.message.from_user.username}</b> спарировал шлепок от @{redis_db.get_username_by_id(other_user_id)} и сделал его уязвимым на день!", quote=False, parse_mode=ParseMode.HTML)
+        await update.message.reply_text(f"ИДЕАЛЬНОЕ ПАРИРОВАНИЕ! <b>{update.message.from_user.username}</b> спарировал шлепок от @{redis_db.get_username_by_id(other_user_id)} и сделал его уязвимым на день!", quote=False, parse_mode=ParseMode.HTML)
         stats.pop(SS_LAST_SLAPPED_DATE, None)
         stats.pop(SS_LAST_SLAPPED_BY_USERID, None)
         r.hset(SLAP_STATS_HASH, str(update.message.from_user.id), json.dumps(stats))
@@ -186,19 +186,19 @@ def parry(update: Update, context):
         other_user_id = stats.get(SS_LAST_SLAPPED_BY_USERID, -1)
         other_user_stats = get_slap_stats(other_user_id)
         other_user_stats[SS_TOTAL_SLAPS] = other_user_stats.get(SS_TOTAL_SLAPS, 0) - 1
-        update.message.reply_text(f"<b>{update.message.from_user.username}</b> спарировал шлепок от @{redis_db.get_username_by_id(other_user_id)}!", quote=False, parse_mode=ParseMode.HTML)
+        await update.message.reply_text(f"<b>{update.message.from_user.username}</b> спарировал шлепок от @{redis_db.get_username_by_id(other_user_id)}!", quote=False, parse_mode=ParseMode.HTML)
         stats.pop(SS_LAST_SLAPPED_DATE, None)
         stats.pop(SS_LAST_SLAPPED_BY_USERID, None)
         r.hset(SLAP_STATS_HASH, str(update.message.from_user.id), json.dumps(stats))
         r.hset(SLAP_STATS_HASH, str(other_user_id), json.dumps(other_user_stats))
     else:
-        update.message.reply_text("Парирование провалено", quote=True)
+        await update.message.reply_text("Парирование провалено", quote=True)
         stats.pop(SS_LAST_SLAPPED_DATE, None)
         stats.pop(SS_LAST_SLAPPED_BY_USERID, None)
         r.hset(SLAP_STATS_HASH, str(update.message.from_user.id), json.dumps(stats))
 
 
-def slap_stats(update: Update, context):
+async def slap_stats(update: Update, context: CallbackContext):
     if (not in_whitelist(update)):
         return
     slappers_dict = {}
@@ -207,7 +207,7 @@ def slap_stats(update: Update, context):
         slappers_dict[username] = get_slap_stats(key)
                 
     if len(slappers_dict.keys()) == 0:
-        update.message.reply_text("Пока что никто никого не шлепал, поэтому и статистики нет", quote=False)
+        await update.message.reply_text("Пока что никто никого не шлепал, поэтому и статистики нет", quote=False)
         return
     message = f"Вот статистика шлепунов.\nИгрок [Шлеп-счет]  (Успешные шлепки / Лечения / Парирования / Идеальные парирования)\n\n"
     i = 1
@@ -223,10 +223,10 @@ def slap_stats(update: Update, context):
     time_to_next = datetime.combine(tomorrow, time.min) - datetime.now()
     time_to_next_h, time_to_next_m = time_to_next.seconds // 3600, (time_to_next.seconds // 60) % 60
     message += f"Новые шлепки будут доступны через {time_to_next_h} ч. и {time_to_next_m} м."
-    update.message.reply_text(f"{message}", quote=False, parse_mode=ParseMode.HTML)
+    await update.message.reply_text(f"{message}", quote=False, parse_mode=ParseMode.HTML)
 
 
-def slap_rules(update: Update, context):
+async def slap_rules(update: Update, context: CallbackContext):
     if (not in_whitelist(update)):
         return
     rules = "Правила /slap игры.\n" + \
@@ -236,16 +236,16 @@ def slap_rules(update: Update, context):
             "Вместо шлепка ты можешь полечить кого-нибудь, отправив /heal и указав другого игрока. Это увеличит его шлеп-счет на 1, а также снимет уязвимость.\n" + \
             "За день ты можешь делать только один шлепок или лечение, но сколько угодно парирований.\n" + \
             "Отправь /slapstats, чтобы посмотреть общую статистику по игре."
-    update.message.reply_text(rules, quote=False)
+    await update.message.reply_text(rules, quote=False)
 
 
-def reset_my_slap(update: Update, context):
+async def reset_my_slap(update: Update, context: CallbackContext):
     if (not in_whitelist(update)):
         return
     stats = get_slap_stats(update.message.from_user.id)
     stats.pop(SS_MADE_ACTION_DATE, None)
     r.hset(SLAP_STATS_HASH, str(update.message.from_user.id), json.dumps(stats))
-    update.message.reply_text("You can now /slap again. This is a debug command that should be removed on prod", quote=False)
+    await update.message.reply_text("You can now /slap again. This is a debug command that should be removed on prod", quote=False)
 
 
 def subscribe(u: Updater):

--- a/taki.py
+++ b/taki.py
@@ -118,13 +118,13 @@ def get_taki_keyboard(guesses: List[int]) -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(key_rows)
 
 
-def takistart(update: Update, context: CallbackContext):
+async def takistart(update: Update, context: CallbackContext):
     if not in_whitelist(update):
         return
 
     # Do not allow starting a new game until the current one is finished (can be abused for stats)
     if len(games_data) > 0 and not games_data[-1].is_finished():
-        update.message.reply_text("Эй, сначала закончи прошлую игру!", reply_to_message_id=games_data[-1].game_message_id.split('/')[1])
+        await update.message.reply_text("Эй, сначала закончи прошлую игру!", reply_to_message_id=games_data[-1].game_message_id.split('/')[1])
         return
 
     difficulty = DEFAULT_DIFFICULTY
@@ -135,7 +135,7 @@ def takistart(update: Update, context: CallbackContext):
             if again_setter:
                 again_setter(lambda: takistart(update, context))
         else:
-            update.message.reply_text("Это уже слишком, приятель. Выбери сложность из: " + ", ".join(map(str, DIFFICULTIES.keys())), quote=True)
+            await update.message.reply_text("Это уже слишком, приятель. Выбери сложность из: " + ", ".join(map(str, DIFFICULTIES.keys())), quote=True)
             return
 
     prev_suspects = list(prev_suspect_uids)
@@ -160,13 +160,13 @@ def takistart(update: Update, context: CallbackContext):
 
     new_game = GameState(game_message_id="", difficulty=difficulty, suspect_uid=sus_uid, suspect_name=sus_name,
                          suspect_msgs=sus_msgs, guesses=[], guesser_uids=[], start_msgs=random.choice(START_MESSAGES), action_log="")
-    message = update.message.reply_text(format_playing_field(new_game), reply_markup=get_taki_keyboard([]), quote=False)
+    message = await update.message.reply_text(format_playing_field(new_game), reply_markup=get_taki_keyboard([]), quote=False)
     new_game.game_message_id = str(message.chat_id) + "/" + str(message.message_id)
     games_data.append(new_game)
     prev_suspect_uids.append(sus_uid)
 
 
-def takistats(update: Update, context: CallbackContext):
+async def takistats(update: Update, context: CallbackContext):
     if not in_whitelist(update):
         return
     difficulty = DEFAULT_DIFFICULTY
@@ -175,7 +175,7 @@ def takistats(update: Update, context: CallbackContext):
         if (req_diff := int(diff_match.group(1))) in DIFFICULTIES:
             difficulty = req_diff
         else:
-            update.message.reply_text("Это уже слишком, приятель. Выбери сложность из: " + ", ".join(map(str, DIFFICULTIES.keys())), quote=True)
+            await update.message.reply_text("Это уже слишком, приятель. Выбери сложность из: " + ", ".join(map(str, DIFFICULTIES.keys())), quote=True)
             return
 
     user_cache = {}
@@ -229,25 +229,25 @@ def takistats(update: Update, context: CallbackContext):
     if len(kdratios) == 0:
         text += "[ДАННЫЕ УДАЛЕНЫ]\n"
 
-    update.message.reply_text(text, quote=False)
+    await update.message.reply_text(text, quote=False)
 
 
-def on_taki_action(update: Update, context: CallbackContext):
+async def on_taki_action(update: Update, context: CallbackContext):
     query = update.callback_query
     if query.data == 't_blank':
-        query.answer()
+        await query.answer()
         return
     
     message_id = str(query.message.chat_id) + "/" + str(query.message.message_id)
     game = next((game for game in games_data if game.game_message_id == message_id), None)
     if game is None:
-        query.answer("Не могу найти данные этой игры :(")
+        await query.answer("Не могу найти данные этой игры :(")
         return
 
     guess_uid = int(query.data[2:])
     guess_name = next((name for uid, (name, _) in taki_suspects.items() if uid == guess_uid), "???")
     if guess_uid in game.guesses:
-        query.answer()
+        await query.answer()
         return
 
     prev_game = copy.deepcopy(game)
@@ -279,7 +279,7 @@ def on_taki_action(update: Update, context: CallbackContext):
         else:
             game.action_log = f"Подозреваемый {game.suspect_name} скрывается в закате. {random.choice(LOSE_MESSAGES)}"
 
-        if commit_game := try_edit(query, game, None):
+        if commit_game := await try_edit(query, game, None):
             games_data.remove(game)
         else:
             for index, stored_game in enumerate(games_data):
@@ -287,7 +287,7 @@ def on_taki_action(update: Update, context: CallbackContext):
                     games_data[index] = prev_game
     else:
         game.action_log = f"{guesser_name} выбирает подозреваемого {guess_name}..."
-        if not (commit_game := try_edit(query, game, get_taki_keyboard(game.guesses))):
+        if not (commit_game := await try_edit(query, game, get_taki_keyboard(game.guesses))):
             for index, stored_game in enumerate(games_data):
                 if stored_game == game:
                     games_data[index] = prev_game
@@ -314,17 +314,17 @@ def on_taki_action(update: Update, context: CallbackContext):
                 r.zrem(f"{RKEY_CURR_STREAK}_{game.difficulty}", guesser_id)
 
 
-def try_edit(query: CallbackQuery, game: GameState, reply_markup) -> bool:
+async def try_edit(query: CallbackQuery, game: GameState, reply_markup) -> bool:
     try:
-        query.edit_message_text(text=format_playing_field(game), reply_markup=reply_markup)
-        query.answer()
+        await query.edit_message_text(text=format_playing_field(game), reply_markup=reply_markup)
+        await query.answer()
         return True
     except RetryAfter:
-        query.answer("Не получилось обновить игру из-за защиты от спама :(")
+        await query.answer("Не получилось обновить игру из-за защиты от спама :(")
         return False
     except Exception as e:
         print(e)
-        query.answer()
+        await query.answer()
         return True
 
 

--- a/taki.py
+++ b/taki.py
@@ -3,7 +3,7 @@ from collections import deque
 from dataclasses import dataclass
 from telegram import CallbackQuery, Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.error import RetryAfter
-from telegram.ext import Updater, CommandHandler, CallbackQueryHandler, CallbackContext
+from telegram.ext import Application, CallbackContext, CommandHandler, CallbackQueryHandler
 from utils import in_whitelist
 from _secrets import taki_suspects
 import redis_db
@@ -328,9 +328,9 @@ async def try_edit(query: CallbackQuery, game: GameState, reply_markup) -> bool:
         return True
 
 
-def subscribe(u: Updater, _again_setter):
-    u.dispatcher.add_handler(CommandHandler(("taki"), takistart))
-    u.dispatcher.add_handler(CommandHandler(("takistats"), takistats))
-    u.dispatcher.add_handler(CallbackQueryHandler(on_taki_action, pattern="^t_"))
+def subscribe(a: Application, _again_setter):
+    a.add_handler(CommandHandler(("taki"), takistart))
+    a.add_handler(CommandHandler(("takistats"), takistats))
+    a.add_handler(CallbackQueryHandler(on_taki_action, pattern="^t_"))
     global again_setter
     again_setter = _again_setter

--- a/taki.py
+++ b/taki.py
@@ -135,7 +135,7 @@ async def takistart(update: Update, context: CallbackContext):
             if again_setter:
                 again_setter(lambda: takistart(update, context))
         else:
-            await update.message.reply_text("Это уже слишком, приятель. Выбери сложность из: " + ", ".join(map(str, DIFFICULTIES.keys())), quote=True)
+            await update.message.reply_text("Это уже слишком, приятель. Выбери сложность из: " + ", ".join(map(str, DIFFICULTIES.keys())), do_quote=True)
             return
 
     prev_suspects = list(prev_suspect_uids)
@@ -160,7 +160,7 @@ async def takistart(update: Update, context: CallbackContext):
 
     new_game = GameState(game_message_id="", difficulty=difficulty, suspect_uid=sus_uid, suspect_name=sus_name,
                          suspect_msgs=sus_msgs, guesses=[], guesser_uids=[], start_msgs=random.choice(START_MESSAGES), action_log="")
-    message = await update.message.reply_text(format_playing_field(new_game), reply_markup=get_taki_keyboard([]), quote=False)
+    message = await update.message.reply_text(format_playing_field(new_game), reply_markup=get_taki_keyboard([]), do_quote=False)
     new_game.game_message_id = str(message.chat_id) + "/" + str(message.message_id)
     games_data.append(new_game)
     prev_suspect_uids.append(sus_uid)
@@ -175,7 +175,7 @@ async def takistats(update: Update, context: CallbackContext):
         if (req_diff := int(diff_match.group(1))) in DIFFICULTIES:
             difficulty = req_diff
         else:
-            await update.message.reply_text("Это уже слишком, приятель. Выбери сложность из: " + ", ".join(map(str, DIFFICULTIES.keys())), quote=True)
+            await update.message.reply_text("Это уже слишком, приятель. Выбери сложность из: " + ", ".join(map(str, DIFFICULTIES.keys())), do_quote=True)
             return
 
     user_cache = {}
@@ -229,7 +229,7 @@ async def takistats(update: Update, context: CallbackContext):
     if len(kdratios) == 0:
         text += "[ДАННЫЕ УДАЛЕНЫ]\n"
 
-    await update.message.reply_text(text, quote=False)
+    await update.message.reply_text(text, do_quote=False)
 
 
 async def on_taki_action(update: Update, context: CallbackContext):

--- a/taki.py
+++ b/taki.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from telegram import CallbackQuery, Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.error import RetryAfter
 from telegram.ext import Application, CallbackContext, CommandHandler, CallbackQueryHandler
-from utils import in_whitelist
 from _secrets import taki_suspects
 import redis_db
 import re
@@ -119,9 +118,6 @@ def get_taki_keyboard(guesses: List[int]) -> InlineKeyboardMarkup:
 
 
 async def takistart(update: Update, context: CallbackContext):
-    if not in_whitelist(update):
-        return
-
     # Do not allow starting a new game until the current one is finished (can be abused for stats)
     if len(games_data) > 0 and not games_data[-1].is_finished():
         await update.message.reply_text("Эй, сначала закончи прошлую игру!", reply_to_message_id=games_data[-1].game_message_id.split('/')[1])
@@ -167,8 +163,6 @@ async def takistart(update: Update, context: CallbackContext):
 
 
 async def takistats(update: Update, context: CallbackContext):
-    if not in_whitelist(update):
-        return
     difficulty = DEFAULT_DIFFICULTY
     diff_match = re.match(r'/[\S]+\s+(\d+)', update.message.text)
     if diff_match is not None:

--- a/uptime.py
+++ b/uptime.py
@@ -19,7 +19,7 @@ async def uptime(update: Update, context):
 
     message = f"{hours:02}:{minutes:02}:{seconds:02}  {lucky_numbers.get(hours, '')}"
 
-    await update.message.reply_text(message, quote=False)
+    await update.message.reply_text(message, do_quote=False)
 
 
 def subscribe(u: Updater):

--- a/uptime.py
+++ b/uptime.py
@@ -1,5 +1,5 @@
 from telegram import Update
-from telegram.ext import Updater, CommandHandler
+from telegram.ext import Application, CallbackContext, CommandHandler
 from utils import in_whitelist
 import logging
 from _secrets import lucky_numbers
@@ -8,7 +8,7 @@ import time
 logger = logging.getLogger(__name__)
 start_time = time.time()
 
-async def uptime(update: Update, context):
+async def uptime(update: Update, context: CallbackContext):
     if (not in_whitelist(update)):
         return
     now = time.time()
@@ -22,5 +22,5 @@ async def uptime(update: Update, context):
     await update.message.reply_text(message, do_quote=False)
 
 
-def subscribe(u: Updater):
-    u.dispatcher.add_handler(CommandHandler(("uptime"), uptime))
+def subscribe(a: Application):
+    a.add_handler(CommandHandler(("uptime"), uptime))

--- a/uptime.py
+++ b/uptime.py
@@ -8,7 +8,7 @@ import time
 logger = logging.getLogger(__name__)
 start_time = time.time()
 
-def uptime(update: Update, context):
+async def uptime(update: Update, context):
     if (not in_whitelist(update)):
         return
     now = time.time()
@@ -19,7 +19,7 @@ def uptime(update: Update, context):
 
     message = f"{hours:02}:{minutes:02}:{seconds:02}  {lucky_numbers.get(hours, '')}"
 
-    update.message.reply_text(message, quote=False)
+    await update.message.reply_text(message, quote=False)
 
 
 def subscribe(u: Updater):

--- a/uptime.py
+++ b/uptime.py
@@ -1,6 +1,5 @@
 from telegram import Update
 from telegram.ext import Application, CallbackContext, CommandHandler
-from utils import in_whitelist
 import logging
 from _secrets import lucky_numbers
 import time
@@ -9,8 +8,6 @@ logger = logging.getLogger(__name__)
 start_time = time.time()
 
 async def uptime(update: Update, context: CallbackContext):
-    if (not in_whitelist(update)):
-        return
     now = time.time()
     diff_seconds = now - start_time
     hours = int(diff_seconds // 3600)

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,4 @@
-from _secrets import secrets_chat_ids, user_aliases
-from telegram import Update
+from _secrets import user_aliases
 from telegram.ext import CallbackContext
 import logging
 import random
@@ -10,17 +9,6 @@ logger = logging.getLogger(__name__)
 
 # Don't include apostrophe
 PUNCTUATION_REGEX = re.compile(r'[\s{}]+'.format(re.escape(r'!"#$%&()*+, -./:;<=>?@[\]^_`{|}~')))
-
-def in_whitelist(update: Update, send_warning=True) -> bool:
-    if (update.message.chat_id not in secrets_chat_ids):
-        logger.warn(f"Blacklisted chat id: {update.message.chat_id}")
-        # Bots have a global limit of 30 messages per second
-        # https://core.telegram.org/bots/faq#broadcasting-to-users
-        # We don't want to enable ddos attacks for blacklisted chats so we dont message them anything
-        if False and send_warning:
-             update.message.reply_text("This chat is not whitelisted")
-        return False
-    return True
 
 
 def parse_userid(username: str, context: CallbackContext):

--- a/utils/announcer.py
+++ b/utils/announcer.py
@@ -1,19 +1,25 @@
 import sys
 import os
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import asyncio
+from telegram import Bot
+from telegram.constants import ParseMode
 
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from _secrets import secrets_bot_token
-from telegram import ParseMode
-from telegram.ext import Updater
+
+
+async def main():
+    if len(sys.argv) < 2:
+        print("Provide chat ID as a command line argument")
+        return
+
+    print(f"Enter a message that will be sent to chat {sys.argv[1]}. Press Ctrl+D to send.")
+
+    message = sys.stdin.read()
+    if message != "":
+        async with Bot(token=secrets_bot_token) as bot:
+            await bot.send_message(chat_id=sys.argv[1], text=message, parse_mode=ParseMode.MARKDOWN)
 
 
 if __name__ == '__main__':
-    if (len(sys.argv) < 2):
-         print("Provide chat ID as a command line argument")
-         quit()
-    u = Updater(secrets_bot_token, use_context=True)
-    print(f"Enter a message that will be sent to chat {sys.argv[1]}. Press Ctrl+D to send.")
-    
-    message = sys.stdin.read()
-    if (message != ""):
-        u.bot.send_message(chat_id=sys.argv[1], text=message, parse_mode=ParseMode.MARKDOWN)
+    asyncio.run(main())


### PR DESCRIPTION
We need a newer `python-telegram-bot` version to use the new Bot API features (guess which).

The PR is best reviewed commit-by-commit:
* The first two commits perform simple find-and-replace and can be skimmed. They are added to `.git-blame-ignore-revs` so they won't pollute `git blame`; please merge the PR without squashing for the file to apply cleanly.
* The third commit deals with actual API changes and may warrant a closer look.
* The fourth commit is not strictly necessary but results in a nice -100 LoC simplification across all modules. It does change the semantics of `/ping` as it will become restricted to the whitelisted chats. If the goal of whitelisting is DoS protection, I think this is a positive change. But if you want to keep it unrestricted, we can move the ping handler to a group that runs before the whitelist gate.